### PR TITLE
Add a unique_id category for pseudonymous identifiers

### DIFF
--- a/data_categories.csv
+++ b/data_categories.csv
@@ -55,6 +55,7 @@ derived_sexual_orientation,Derived Sexual Orientation,user_identifiable_data,Per
 derived_non_specific_age,Derived Non-Specific Age,user_identifiable_data,Age range information.
 derived_workplace,Derived Workplace,user_identifiable_data,Organization of employment.
 derived_religious_belief,Derived Religious Belief,user_identifiable_data,Religion or religious belief.
+unique_id,Unique ID,user_identifiable_data,Unique identifier for a user assigned through system use.
 device_id,Device ID,device_data,Device unique identification number.
 cookie_id,Cookie ID,device_data,Cookie unique identification number.
 ip_address,IP Address,device_data,Unique identifier related to device connection.

--- a/data_categories.json
+++ b/data_categories.json
@@ -329,6 +329,12 @@
             "description": "Religion or religious belief."
         },
         {
+            "fidesKey": "unique_id",
+            "name": "Unique ID",
+            "parentKey": "user_identifiable_data",
+            "description": "Unique identifier for a user assigned through system use."
+        },
+        {
             "fidesKey": "device_id",
             "name": "Device ID",
             "parentKey": "device_data",

--- a/data_categories.yml
+++ b/data_categories.yml
@@ -279,6 +279,11 @@ data-category:
     parentKey: user_identifiable_data
     description: "Religion or religious belief."
 
+  - fidesKey: unique_id
+    name: "Unique ID"
+    parentKey: user_identifiable_data
+    description: "Unique identifier for a user assigned through system use."
+
   # Derived Data -> Device Data
   - fidesKey: device_id
     name: "Device ID"


### PR DESCRIPTION
This covers the (very common) case of assigning a `uuid` or similar to a user within your system. Making this an explicit category within `user_identifiable_data` parent should make it clear how to annotate this in your data!