### PR TITLE
Added descriptions for all categories of data use.

### DIFF
--- a/data_subjects.csv
+++ b/data_subjects.csv
@@ -1,17 +1,17 @@
-fidesKey,name,parentKey
-data_subject,Data Subject,
-anonymous_user,Anonymous User,data_subject
-citizen_voter,Citizen Voter,data_subject
-commuter,Commuter,data_subject
-consultant,Consultant,data_subject
-customer,Custom,data_subject
-employee,Employee,data_subject
-job_applicant,Job Applicant,data_subject
-next_of_kin,Next of Kin,data_subject
-passenger,Passenger,data_subject
-patient,Patient,data_subject
-prospect,Prospect,data_subject
-shareholder,Shareholder,data_subject
-supplier_vendor,Supplier/Vendor,data_subject
-trainee,Trainee,data_subject
-visitor,Visitor,data_subject
+fidesKey,name,parentKey,description
+data_subject,Data Subject,,
+anonymous_user,Anonymous User,data_subject,An individual that is unidentifiable to the systems. Please note: This should only be applied to truly anonymous users where there is no risk of re-identification
+citizen_voter,Citizen Voter,data_subject,An individual registered to voter with a state or authority.
+commuter,Commuter,data_subject,An individual that is traveling or transiting in the context of location tracking.
+consultant,Consultant,data_subject,An individual employed in a consultative/temporary capacity by the organization.
+customer,Custom,data_subject,An individual or other organization that purchases goods or services from the organization.
+employee,Employee,data_subject,An individual employed by the organization.
+job_applicant,Job Applicant,data_subject,An individual applying for employment to the organization.
+next_of_kin,Next of Kin,data_subject,A relative of any other individual subject where such a relationship is known.
+passenger,Passenger,data_subject,An individual traveling on some means of provided transport.
+patient,Patient,data_subject,An individual identified for the purposes of any medical care.
+prospect,Prospect,data_subject,An individual or organization to whom an organization is selling goods or services.
+shareholder,Shareholder,data_subject,An individual or organization that holds equity in the organization.
+supplier_vendor,Supplier/Vendor,data_subject,An individual or organization that provides services or goods to the organization.
+trainee,Trainee,data_subject,An individual undergoing training by the organization.
+visitor,Visitor,data_subject,An individual visiting a location.

--- a/data_subjects.json
+++ b/data_subjects.json
@@ -2,63 +2,78 @@
     "data_subject": [
         {
             "fidesKey": "anonymous_user",
-            "name": "Anonymous User"
+            "name": "Anonymous User",
+            "description": "An individual that is unidentifiable to the systems. Please note: This should only be applied to truly anonymous users where there is no risk of re-identification"
         },
         {
             "fidesKey": "citizen_voter",
-            "name": "Citizen Voter"
+            "name": "Citizen Voter",
+            "description": "An individual registered to voter with a state or authority."
         },
         {
             "fidesKey": "commuter",
-            "name": "Commuter"
+            "name": "Commuter",
+            "description": "An individual that is traveling or transiting in the context of location tracking."
         },
         {
             "fidesKey": "consultant",
-            "name": "Consultant"
+            "name": "Consultant",
+            "description": "An individual employed in a consultative/temporary capacity by the organization."
         },
         {
             "fidesKey": "customer",
-            "name": "Custom"
+            "name": "Custom",
+            "description": "An individual or other organization that purchases goods or services from the organization."
         },
         {
             "fidesKey": "employee",
-            "name": "Employee"
+            "name": "Employee",
+            "description": "An individual employed by the organization."
         },
         {
             "fidesKey": "job_applicant",
-            "name": "Job Applicant"
+            "name": "Job Applicant",
+            "description": "An individual applying for employment to the organization."
         },
         {
             "fidesKey": "next_of_kin",
-            "name": "Next of Kin"
+            "name": "Next of Kin",
+            "description": "A relative of any other individual subject where such a relationship is known."
         },
         {
             "fidesKey": "passenger",
-            "name": "Passenger"
+            "name": "Passenger",
+            "description": "An individual traveling on some means of provided transport."
         },
         {
             "fidesKey": "patient",
-            "name": "Patient"
+            "name": "Patient",
+            "description": "An individual identified for the purposes of any medical care."
         },
         {
             "fidesKey": "prospect",
-            "name": "Prospect"
+            "name": "Prospect",
+            "description": "An individual or organization to whom an organization is selling goods or services."
         },
         {
             "fidesKey": "shareholder",
-            "name": "Shareholder"
+            "name": "Shareholder",
+            "description": "An individual or organization that holds equity in the organization."
         },
         {
             "fidesKey": "supplier_vendor",
-            "name": "Supplier/Vendor"
+            "name": "Supplier/Vendor",
+            "description": "An individual or organization that provides services or goods to the organization."
         },
         {
             "fidesKey": "trainee",
-            "name": "Trainee"
+            "name": "Trainee",
+            "description": "An individual undergoing training by the organization."
         },
         {
             "fidesKey": "visitor",
-            "name": "Visitor"
+            "name": "Visitor",
+            "description": "An individual visiting a location."
         }
     ]
 }

--- a/data_subjects.yml
+++ b/data_subjects.yml
@@ -1,45 +1,61 @@
 data_subject:
-  - fidesKey: "anonymous_user"
+  - fidesKey: anonymous_user
     name: "Anonymous User"
+    description: "An individual that is unidentifiable to the systems. 
+    Please note: This should only be applied to truly anonymous users where there is no risk of re-identification"
 
-  - fidesKey: "citizen_voter"
+  - fidesKey: citizen_voter
     name: "Citizen Voter"
+    description: "An individual registered to voter with a state or authority."
 
-  - fidesKey: "commuter"
+  - fidesKey: commuter
     name: "Commuter"
+    description: "An individual that is traveling or transiting in the context of location tracking."
 
-  - fidesKey: "consultant"
+  - fidesKey: consultant
     name: "Consultant"
+    description: "An individual employed in a consultative/temporary capacity by the organization."
 
-  - fidesKey: "customer"
+  - fidesKey: customer
     name: "Custom"
+    description: "An individual or other organization that purchases goods or services from the organization."
 
-  - fidesKey: "employee"
+  - fidesKey: employee
     name: "Employee"
+    description: "An individual employed by the organization."
 
-  - fidesKey: "job_applicant"
+  - fidesKey: job_applicant
     name: "Job Applicant"
-
-  - fidesKey: "next_of_kin"
+    description: "An individual applying for employment to the organization."
+    
+  - fidesKey: next_of_kin
     name: "Next of Kin"
-
-  - fidesKey: "passenger"
+    description: "A relative of any other individual subject where such a relationship is known."
+    
+  - fidesKey: passenger
     name: "Passenger"
-
-  - fidesKey: "patient"
+    description: "An individual traveling on some means of provided transport."
+    
+  - fidesKey: patient
     name: "Patient"
-
-  - fidesKey: "prospect"
+    description: "An individual identified for the purposes of any medical care."
+    
+  - fidesKey: prospect
     name: "Prospect"
-
-  - fidesKey: "shareholder"
+    description: "An individual or organization to whom an organization is selling goods or services."
+    
+  - fidesKey: shareholder
     name: "Shareholder"
-
-  - fidesKey: "supplier_vendor"
+    description: "An individual or organization that holds equity in the organization."
+    
+  - fidesKey: supplier_vendor
     name: "Supplier/Vendor"
-
-  - fidesKey: "trainee"
+    description: "An individual or organization that provides services or goods to the organization."
+    
+  - fidesKey: trainee
     name: "Trainee"
-
-  - fidesKey: "visitor"
+    description: "An individual undergoing training by the organization."
+    
+  - fidesKey: visitor
     name: "Visitor"
+    description: "An individual visiting a location."

--- a/data_uses.csv
+++ b/data_uses.csv
@@ -1,20 +1,21 @@
-fidesKey,name,parentKey
-data_use,Data Use,
-provide_the_product_or_service,Provide the Product or Service,data_use
-support_the_product_or_service,Support the Product or Service,provide_the_product_or_service
-support_optimization,Support Optimization,provide_the_product_or_service
-offers_of_product_or_service_upgrades,Offers of Product or Service Upgrades,provide_the_product_or_service
-improve_the_product_or_service,Improve the Product or Service,data_use
-personalize_the_product_or_service,Personalize the Product or Service,data_use
-marketing_advertising_or_promotion,"Marketing, Advertising or Promotion",data_use
-first_party_advertising,First Party Advertising,marketing_advertising_or_promotion
-third_party_advertising,Third Party Advertising,marketing_advertising_or_promotion
-first_party_contextual_advertising,First Party Contextual Advertising,first_party_advertising
-first_party_personalized_advertising,First Party Personalized Advertising,first_party_advertising
-third_party_personalized_advertising,Third Party Personalized Advertising,third_party_advertising
-third_party_sharing,Third Party Sharing,data_use
-sharing_for_processing_payments,Sharing for Processing Payments,third_party_sharing
-sharing_for_personalized_advertising,Sharing for Personalized Advertising,third_party_sharing
-sharing_for_legal_obligation,Sharing for Legal Obligation,third_party_sharing
-collect,Collect,data_use
-train_ai_system,Train AI System,data_use
+fidesKey,name,parentKey,description
+data_use,Data Use,,
+provide_product_or_service,Provide the Product or Service,data_use,Use of specified data categories to provide the proposed service to the user.
+support_product_or_service,Support the Product or Service,provide_product_or_service,Use of specified data categories to operate and protect the system in order to provide the service.
+support_optimization,Support Optimization,provide_product_or_service,Use of specified data categories to ensure appropriate support for the service is being provided.
+offers_of_product_or_service_upgrades,Offers of Product or Service Upgrades,provide_product_or_service,Offer upgrades or upsales such as increased capacity for the service based on monitoring of service usage.
+improve_the_product_or_service,Improve the Product or Service,data_use,Use specified data categories related to the user or system in order to improve the quality of the service.
+personalize_product_or_service,Personalize the Product or Service,data_use,Use of specified data categories for the purpose of personalizing the features or services of the application.
+marketing_advertising_or_promotion,"Marketing, Advertising or Promotion",data_use,The promotion of products or services targeted to users based on the the processing of user provided data in the system.
+first_party_advertising,First Party Advertising,marketing_advertising_or_promotion,The promotion of products or services targeting users based on processing of derviced data from prior use of the system.
+third_party_advertising,Third Party Advertising,marketing_advertising_or_promotion,The promotion of products or services targeting users based on processing of specific categories of data acquired from third party sources.
+first_party_contextual_advertising,First Party Contextual Advertising,first_party_advertising,The promotion of products or services targeted to users based on the processing of derived data from the users prior use of the services.
+first_party_personalized_advertising,First Party Personalized Advertising,first_party_advertising,The targeting and changing of promotional content based on processing of specific data categories from the user.
+third_party_personalized_advertising,Third Party Personalized Advertising,third_party_advertising,The targeting and changing of promotional content based on processing of specific categories of user data acquired from third party sources.
+third_party_sharing,Third Party Sharing,data_use,The transfer of specified data categories to third parties outside of the system/application's scope.
+sharing_for_processing_payments,Sharing for Processing Payments,third_party_sharing,Sharing of specified data categories with a third party for payment processing.
+sharing_for_personalized_advertising,Sharing for Personalized Advertising,third_party_sharing,Sharing of specified data categories for the purpose of marketing/advertising/promotion.
+sharing_for_fraud_detection,Sharing for Fraud Detection,third_party_sharing,Sharing of specified data categories with a third party fo fraud prevention/detection.
+sharing_for_legal_obligation,Sharing for Legal Obligation,third_party_sharing,"Sharing of data for legal obligations, including contracts, applicable laws or regulations."
+collect,Collect,data_use,Collecting and storing data in order to use it for another purpose such as data training for ML.
+train_ai_system,Train AI System,data_use,"Training an AI system. Please note when this data use is specified, the method and degree to which a user may be directly identified in the resulting AI system should be appended."

--- a/data_uses.json
+++ b/data_uses.json
@@ -1,87 +1,111 @@
 {
     "data_use": [
         {
-            "fidesKey": "provide_the_product_or_service",
-            "name": "Provide the Product or Service"
+            "fidesKey": "provide_product_or_service",
+            "name": "Provide the Product or Service",
+            "description": "Use of specified data categories to provide the proposed service to the user."
         },
         {
-            "fidesKey": "support_the_product_or_service",
+            "fidesKey": "support_product_or_service",
             "name": "Support the Product or Service",
-            "parentKey": "provide_the_product_or_service"
+            "parentKey": "provide_product_or_service",
+            "description": "Use of specified data categories to operate and protect the system in order to provide the service."
         },
         {
             "fidesKey": "support_optimization",
             "name": "Support Optimization",
-            "parentKey": "provide_the_product_or_service"
+            "parentKey": "provide_product_or_service",
+            "description": "Use of specified data categories to ensure appropriate support for the service is being provided."
         },
         {
             "fidesKey": "offers_of_product_or_service_upgrades",
             "name": "Offers of Product or Service Upgrades",
-            "parentKey": "provide_the_product_or_service"
+            "parentKey": "provide_product_or_service",
+            "description": "Offer upgrades or upsales such as increased capacity for the service based on monitoring of service usage."
         },
         {
             "fidesKey": "improve_the_product_or_service",
-            "name": "Improve the Product or Service"
+            "name": "Improve the Product or Service",
+            "description": "Use specified data categories related to the user or system in order to improve the quality of the service."
         },
         {
-            "fidesKey": "personalize_the_product_or_service",
-            "name": "Personalize the Product or Service"
+            "fidesKey": "personalize_product_or_service",
+            "name": "Personalize the Product or Service",
+            "description": "Use of specified data categories for the purpose of personalizing the features or services of the application."
         },
         {
             "fidesKey": "marketing_advertising_or_promotion",
-            "name": "Marketing, Advertising or Promotion"
+            "name": "Marketing, Advertising or Promotion",
+            "description": "The promotion of products or services targeted to users based on the the processing of user provided data in the system."
         },
         {
             "fidesKey": "first_party_advertising",
             "name": "First Party Advertising",
-            "parentKey": "marketing_advertising_or_promotion"
+            "parentKey": "marketing_advertising_or_promotion",
+            "description": "The promotion of products or services targeting users based on processing of derviced data from prior use of the system."
         },
         {
             "fidesKey": "third_party_advertising",
             "name": "Third Party Advertising",
-            "parentKey": "marketing_advertising_or_promotion"
+            "parentKey": "marketing_advertising_or_promotion",
+            "description": "The promotion of products or services targeting users based on processing of specific categories of data acquired from third party sources."
         },
         {
             "fidesKey": "first_party_contextual_advertising",
             "name": "First Party Contextual Advertising",
-            "parentKey": "first_party_advertising"
+            "parentKey": "first_party_advertising",
+            "description": "The promotion of products or services targeted to users based on the processing of derived data from the users prior use of the services."
         },
         {
             "fidesKey": "first_party_personalized_advertising",
             "name": "First Party Personalized Advertising",
-            "parentKey": "first_party_advertising"
+            "parentKey": "first_party_advertising",
+            "description": "The targeting and changing of promotional content based on processing of specific data categories from the user."
         },
         {
             "fidesKey": "third_party_personalized_advertising",
             "name": "Third Party Personalized Advertising",
-            "parentKey": "third_party_advertising"
+            "parentKey": "third_party_advertising",
+            "description": "The targeting and changing of promotional content based on processing of specific categories of user data acquired from third party sources."
         },
         {
             "fidesKey": "third_party_sharing",
-            "name": "Third Party Sharing"
+            "name": "Third Party Sharing",
+            "description": "The transfer of specified data categories to third parties outside of the system/application's scope."
         },
         {
             "fidesKey": "sharing_for_processing_payments",
             "name": "Sharing for Processing Payments",
-            "parentKey": "third_party_sharing"
+            "parentKey": "third_party_sharing",
+            "description": "Sharing of specified data categories with a third party for payment processing."
         },
         {
             "fidesKey": "sharing_for_personalized_advertising",
             "name": "Sharing for Personalized Advertising",
-            "parentKey": "third_party_sharing"
+            "parentKey": "third_party_sharing",
+            "description": "Sharing of specified data categories for the purpose of marketing/advertising/promotion."
+        },
+        {
+            "fidesKey": "sharing_for_fraud_detection",
+            "name": "Sharing for Fraud Detection",
+            "parentKey": "third_party_sharing",
+            "description": "Sharing of specified data categories with a third party fo fraud prevention/detection."
         },
         {
             "fidesKey": "sharing_for_legal_obligation",
             "name": "Sharing for Legal Obligation",
-            "parentKey": "third_party_sharing"
+            "parentKey": "third_party_sharing",
+            "description": "Sharing of data for legal obligations, including contracts, applicable laws or regulations."
         },
         {
             "fidesKey": "collect",
-            "name": "Collect"
+            "name": "Collect",
+            "description": "Collecting and storing data in order to use it for another purpose such as data training for ML."
         },
         {
             "fidesKey": "train_ai_system",
-            "name": "Train AI System"
+            "name": "Train AI System",
+            "description": "Training an AI system. Please note when this data use is specified, the method and degree to which a user may be directly identified in the resulting AI system should be appended."
         }
     ]
 }

--- a/data_uses.yml
+++ b/data_uses.yml
@@ -1,74 +1,98 @@
 data_use:
   # Provided Data
-  - fidesKey: "provide_the_product_or_service"
+  - fidesKey: provide_product_or_service
     name: "Provide the Product or Service"
+    description: "Use of specified data categories to provide the proposed service to the user."
 
-  - fidesKey: "support_the_product_or_service"
+  - fidesKey: support_product_or_service
     name: "Support the Product or Service"
-    parentKey: "provide_the_product_or_service"
+    parentKey: provide_product_or_service
+    description: "Use of specified data categories to operate and protect the system in order to provide the service."
 
-  - fidesKey: "support_optimization"
+  - fidesKey: support_optimization
     name: "Support Optimization"
-    parentKey: "provide_the_product_or_service"
+    parentKey: provide_product_or_service
+    description: "Use of specified data categories to ensure appropriate support for the service is being provided."
 
-  - fidesKey: "offers_of_product_or_service_upgrades"
+  - fidesKey: offers_of_product_or_service_upgrades
     name: "Offers of Product or Service Upgrades"
-    parentKey: "provide_the_product_or_service"
+    parentKey: provide_product_or_service
+    description: "Offer upgrades or upsales such as increased capacity for the service based on monitoring of service usage."
 
   # Improvement Data
-  - fidesKey: "improve_the_product_or_service"
+  - fidesKey: improve_the_product_or_service
     name: "Improve the Product or Service"
+    description: "Use specified data categories related to the user or system in order to improve the quality of the service."
 
   # Personalize Data
-  - fidesKey: "personalize_the_product_or_service"
+  - fidesKey: personalize_product_or_service
     name: "Personalize the Product or Service"
+    description: "Use of specified data categories for the purpose of personalizing the features or services of the application."
 
   # Marketing, Advertising or Promotion Data
-  - fidesKey: "marketing_advertising_or_promotion"
+  - fidesKey: marketing_advertising_or_promotion
     name: "Marketing, Advertising or Promotion"
+    description: "The promotion of products or services targeted to users based on the the processing of user provided data in the system."
 
-  - fidesKey: "first_party_advertising"
+  - fidesKey: first_party_advertising
     name: "First Party Advertising"
-    parentKey: "marketing_advertising_or_promotion"
+    parentKey: marketing_advertising_or_promotion
+    description: "The promotion of products or services targeting users based on processing of derviced data from prior use of the system."  
 
-  - fidesKey: "third_party_advertising"
+  - fidesKey: third_party_advertising
     name: "Third Party Advertising"
-    parentKey: "marketing_advertising_or_promotion"
+    parentKey: marketing_advertising_or_promotion
+    description: "The promotion of products or services targeting users based on processing of specific categories of data acquired from third party sources."
 
   # Marketing, Advertising or Promotion -> First Party Advertising
-  - fidesKey: "first_party_contextual_advertising"
+  - fidesKey: first_party_contextual_advertising
     name: "First Party Contextual Advertising"
-    parentKey: "first_party_advertising"
+    parentKey: first_party_advertising
+    description: "The promotion of products or services targeted to users based on the processing of derived data from the users prior use of the services."
 
-  - fidesKey: "first_party_personalized_advertising"
+  - fidesKey: first_party_personalized_advertising
     name: "First Party Personalized Advertising"
-    parentKey: "first_party_advertising"
+    parentKey: first_party_advertising
+    description: "The targeting and changing of promotional content based on processing of specific data categories from the user."
 
   # Marketing, Advertising or Promotion -> Third Party Advertising
-  - fidesKey: "third_party_personalized_advertising"
+  - fidesKey: third_party_personalized_advertising
     name: "Third Party Personalized Advertising"
-    parentKey: "third_party_advertising"
+    parentKey: third_party_advertising
+    description: "The targeting and changing of promotional content based on processing of specific categories of user data acquired from third party sources."
 
   # Third Party Sharing
-  - fidesKey: "third_party_sharing"
+  - fidesKey: third_party_sharing
     name: "Third Party Sharing"
+    description: "The transfer of specified data categories to third parties outside of the system/application's scope."
 
-  - fidesKey: "sharing_for_processing_payments"
+  - fidesKey: sharing_for_processing_payments
     name: "Sharing for Processing Payments"
-    parentKey: "third_party_sharing"
+    parentKey: third_party_sharing
+    description: "Sharing of specified data categories with a third party for payment processing."
 
-  - fidesKey: "sharing_for_personalized_advertising"
+  - fidesKey: sharing_for_personalized_advertising
     name: "Sharing for Personalized Advertising"
-    parentKey: "third_party_sharing"
+    parentKey: third_party_sharing
+    description: "Sharing of specified data categories for the purpose of marketing/advertising/promotion."
 
-  - fidesKey: "sharing_for_legal_obligation"
+  - fidesKey: sharing_for_fraud_detection
+    name: "Sharing for Fraud Detection"
+    parentKey: third_party_sharing
+    description: "Sharing of specified data categories with a third party fo fraud prevention/detection."
+
+  - fidesKey: sharing_for_legal_obligation
     name: "Sharing for Legal Obligation"
-    parentKey: "third_party_sharing"
+    parentKey: third_party_sharing
+    description: "Sharing of data for legal obligations, including contracts, applicable laws or regulations."
 
   # Collect
-  - fidesKey: "collect"
+  - fidesKey: collect
     name: "Collect"
+    description: "Collecting and storing data in order to use it for another purpose such as data training for ML."
 
   # Train AI System
-  - fidesKey: "train_ai_system"
+  - fidesKey: train_ai_system
     name: "Train AI System"
+    description: "Training an AI system.
+Please note when this data use is specified, the method and degree to which a user may be directly identified in the resulting AI system should be appended."


### PR DESCRIPTION
### Purpose
***
Update the `data-uses ` and `data-subject` files to make it consistent structurally with `data-categories` as well as providing descriptions for each data-use and data-subject.

### Changes
---
- Added descriptions for each `data-use` as follows:
  - provide_product_or_service
  - support_product_or_service
  - support_optimization
  - offers_of_product_or_service_upgrades
  - improve_the_product_or_service
  - personalize_product_or_service
  - marketing_advertising_or_promotion
  - first_party_advertising
  - third_party_advertising
  - first_party_contextual_advertising
  - first_party_personalized_advertising
  - third_party_personalized_advertising
  - third_party_sharing
  - sharing_for_processing_payments
  - sharing_for_personalized_advertising
  - sharing_for_fraud_detection
  - sharing_for_legal_obligation
  - collect
  - train_ai_system
- Added descriptions for each `data-subject` as follows:
  - anonymous_user
  - citizen_voter
  - commuter
  - consultant
  - customer
  - employee
  - job_applicant
  - next_of_kin
  - passenger
  - patient
  - prospect
  - shareholder
  - supplier_vendor
  - trainee
  - visitor
- Generated new accompanying .csv and .json for the `data-use` and `data-subject` documents.

