### PR TITLE
Refactor the data categories taxonomy for usability

### DIFF
--- a/data_categories.csv
+++ b/data_categories.csv
@@ -1,75 +1,79 @@
 fidesKey,name,parentKey,description
 data_category,Data Category,,
-user_provided_data,User Provided Data,data_category,Data provided or created directly by a user of the system.
-credentials,Credentials,user_provided_data,User provided authentication data.
-name,Name,user_provided_data,User's real name.
-date_of_birth,Date of Birth,user_provided_data,User's date of birth.
-user_provided_gender,User Provided Gender,user_provided_data,Gender of an individual.
-user_provided_race,User Provided Race,user_provided_data,Racial or ethnic origin data.
-user_provided_sexual_orientation,User Provided Sexual Orientation,user_provided_data,Personal sex life or sexual information.
-user_provided_non_specific_age,User Provided Non-Specific Age,user_provided_data,Age range information.
-job_title,Job Title,user_provided_data,Professional information.
-user_provided_workplace,User Provided Workplace,user_provided_data,Organization of employment.
-user_provided_religious_belief,User Provided Religious Belief,user_provided_data,Religion or religious belief.
-provided_contact_information,Provided Contact Information,user_provided_data,User provided contact information for purposes other than account management.
-health_and_medical_data,Health and Medical Data,user_provided_data,Health records or individual's personal medical information.
-genetic_data,Genetic Data,user_provided_data,Data about the genetic makeup provided by a user.
-biometric_data,Biometric Data,user_provided_data,Encoded characteristics provided by a user.
-childrens_data,Children's Data,user_provided_data,Data relating to children.
-political_opinion,Political Opinion,user_provided_data,Data related to the individual's political opinions.
-financial_data,Financial Data,user_provided_data,Payment data and financial history.
-government_id,Government ID,user_provided_data,State provided identification information.
-user_provided_financial_account_number,User Provided Financial Account Number,financial_data,"User's account number for a payment card, bank account, or other financial system."
-password,Password,credentials,Password for system authentication.
-biometric_credentials,Biometric Credentials,credentials,Credentials for system authentication.
-user_provided_email,User Provided Email,provided_contact_information,User's provided email address.
-user_provided_street,User Provided Street,provided_contact_information,User's street level address information.
-user_provided_city,User Provided City,provided_contact_information,User's city level address information.
-user_provided_state,User Provided State,provided_contact_information,User's state level address information.
-user_provided_postal_code,User Provided Postal Code,provided_contact_information,User's postal code.
-user_provided_country,User Provided Country,provided_contact_information,User's country level address information.
-user_provided_phone_number,User Provided Phone Number,provided_contact_information,User's phone number.
-national_identification_number,National Identification Number,government_id,State issued personal identification number.
-drivers_license_number,Driver's License Number,government_id,State issued driving identification number.
-passport_number,Passport Number,government_id,State issued passport data.
-derived_data,Derived Data,data_category,Data derived from user provided data or as a result of user actions in the system.
-user_identifiable_data,User Identifiable Data,derived_data,"Derived data that is linked to, or identifies a user."
-organization_identifiable_data,Organization Identifiable Data,derived_data,"Derived data that is linked to, or identifies an organization."
-sensor_data,Sensor Data,derived_data,Non-user identifiable measurement data derived from sensors and monitoring systems.
-telemetry_data,Telemetry Data,user_identifiable_data,User identifiable measurement data from system sensors and monitoring.
-device_data,Device Data,user_identifiable_data,"Data related to a user's device, configuration and setting."
-observed_data,Observed Data,user_identifiable_data,Data collected through observation of use of the system.
-demographic_information,Demographic Information,user_identifiable_data,Demographic information about a user.
-profiling_data,Profiling Data,user_identifiable_data,Preference and interest information about a user.
-media_consumption_data,Media Consumption Data,user_identifiable_data,Media type consumption information of a user.
-browsing_history,Browsing History,user_identifiable_data,Content browsing history of a user.
-search_history,Search History,user_identifiable_data,Records of search history and queries of a user.
-location_data,Location Data,user_identifiable_data,Records of the location of a user.
-social_data,Social Data,user_identifiable_data,Social activity and interaction data.
-biometric_health_data,Biometric Health Data,user_identifiable_data,Encoded characteristic collected about a user.
-derived_contact_data,Derived Contact Data,user_identifiable_data,Contact information collected about a user.
-user_sensor_data,User Sensor Data,user_identifiable_data,Measurement data derived about a user's environment through system use.
-derived_gender,Derived Gender,user_identifiable_data,Gender of an individual.
-derived_race,Derived Race,user_identifiable_data,Racial or ethnic origin data.
-derived_sexual_orientation,Derived Sexual Orientation,user_identifiable_data,Personal sex life or sexual information.
-derived_non_specific_age,Derived Non-Specific Age,user_identifiable_data,Age range information.
-derived_workplace,Derived Workplace,user_identifiable_data,Organization of employment.
-derived_religious_belief,Derived Religious Belief,user_identifiable_data,Religion or religious belief.
-unique_id,Unique ID,user_identifiable_data,Unique identifier for a user assigned through system use.
-device_id,Device ID,device_data,Device unique identification number.
-cookie_id,Cookie ID,device_data,Cookie unique identification number.
-ip_address,IP Address,device_data,Unique identifier related to device connection.
-system_data,System Data,data_category,"Data unique to, and under control of the system."
-authentication_data,Authentication Data,system_data,Data used to manage access to the system.
-operations_data,Operations Data,system_data,Data used for system operations.
-account_data,Account Data,data_category,"Data unique to, and under control of the system"
-payment_information,Payment Information,account_data,Payment data related to user's account.
-account_contact_information,Account Contact Information,account_data,Account data related to user contact information.
-account_email,Account Email,account_contact_information,User account's email address.
-account_street,Account Street,account_contact_information,User account's street level address.
-account_city,Account City,account_contact_information,User's city level address information.
-account_state,Account State,account_contact_information,User's state level address information.
-account_postal_code,Account Postal Code,account_contact_information,User's postal code.
-account_country,Account Country,account_contact_information,User's country level address information.
-account_phone_number,Account Phone Number,account_contact_information,User's phone number.
-accounts_financial_account_number,Account's Financial Account Number,payment_information,"User's account number for a payment card, bank account, or other financial system."
+account,Account Data,data_category,"Data related to a system account."
+account.contact,Account Contact Data,account,Contact data related to a system account.
+account.contact.city,Account City,account.contact,Account's city level address data.
+account.contact.country,Account Country,account.contact,Account's country level address data.
+account.contact.email,Account Email,account.contact,Account's email address.
+account.contact.phone_number,Account Phone Number,account.contact,Account's phone number.
+account.contact.postal_code,Account Postal Code,account.contact,Account's postal code.
+account.contact.state,Account State,account.contact,Account's state level address data.
+account.contact.street,Account Street,account.contact,Account's street level address.
+account.payment,Payment Data,account,Payment data related to system account.
+account.payment.financial_account_number,Account Payment Financial Account Number,account.payment,"Financial account number for an account's payment card, bank account, or other financial system."
+system,System Data,data_category,"Data unique to, and under control of the system."
+system.authentication,Authentication Data,system,Data used to manage access to the system.
+system.operations,Operations Data,system,Data used for system operations.
+user,User Data,data_category,"Data related to the user of the system, either provided directly or derived based on their usage."
+user.derived,Derived Data,user,Data derived from user provided data or as a result of user actions in the system.
+user.derived.identifiable,Derived User Identifiable Data,user.derived,"Derived data that is linked to, or identifies a user."
+user.derived.identifiable.biometric_health,Biometric Health Data,user.derived.identifiable,Encoded characteristic collected about a user.
+user.derived.identifiable.browsing_history,Browsing History,user.derived.identifiable,Content browsing history of a user.
+user.derived.identifiable.demographic,Demographic Data,user.derived.identifiable,Demographic data about a user.
+user.derived.identifiable.derived_contact,Derived Contact Data,user.derived.identifiable,Contact data collected about a user.
+user.derived.identifiable.device,Device Data,user.derived.identifiable,"Data related to a user's device, configuration and setting."
+user.derived.identifiable.device.cookie_id,Cookie ID,user.derived.identifiable.device,Cookie unique identification number.
+user.derived.identifiable.device.device_id,Device ID,user.derived.identifiable.device,Device unique identification number.
+user.derived.identifiable.device.ip_address,IP Address,user.derived.identifiable.device,Unique identifier related to device connection.
+user.derived.identifiable.gender,Derived Gender,user.derived.identifiable,Gender of an individual.
+user.derived.identifiable.location,Location Data,user.derived.identifiable,Records of the location of a user.
+user.derived.identifiable.media_consumption,Media Consumption Data,user.derived.identifiable,Media type consumption data of a user.
+user.derived.identifiable.non_specific_age,Derived Non-Specific Age,user.derived.identifiable,Age range data.
+user.derived.identifiable.observed,Observed Data,user.derived.identifiable,Data collected through observation of use of the system.
+user.derived.identifiable.profiling,Profiling Data,user.derived.identifiable,Preference and interest data about a user.
+user.derived.identifiable.race,Derived Race,user.derived.identifiable,Racial or ethnic origin data.
+user.derived.identifiable.religious_belief,Derived Religious Belief,user.derived.identifiable,Religion or religious belief.
+user.derived.identifiable.search_history,Search History,user.derived.identifiable,Records of search history and queries of a user.
+user.derived.identifiable.sexual_orientation,Derived Sexual Orientation,user.derived.identifiable,Personal sex life or sexual data.
+user.derived.identifiable.social,Social Data,user.derived.identifiable,Social activity and interaction data.
+user.derived.identifiable.telemetry,Telemetry Data,user.derived.identifiable,User identifiable measurement data from system sensors and monitoring.
+user.derived.identifiable.unique_id,Unique ID,user.derived.identifiable,Unique identifier for a user assigned through system use.
+user.derived.identifiable.user_sensor,User Sensor Data,user.derived.identifiable,Measurement data derived about a user's environment through system use.
+user.derived.identifiable.organization,Organization Identifiable Data,user.derived,"Derived data that is linked to, or identifies an organization."
+user.derived.identifiable.workplace,Derived Workplace,user.derived.identifiable,Organization of employment.
+user.derived.nonidentifiable,Derived User Non-Identifiable Data,user.derived.nonidentifiable,Non-user identifiable data derived related to a user as a result of user actions in the system.
+user.derived.nonidentifiable.sensor,Sensor Data,user.derived.nonidentifiable,Non-user identifiable measurement data derived from sensors and monitoring systems.
+user.provided,User Provided Data,user,Data provided or created directly by a user of the system.
+user.provided.identifiable,User Provided Identifiable Data,user,Data provided or created directly by a user that is linked to or identifies a user.
+user.provided.identifiable.biometric,Biometric Data,user.provided.identifable,Encoded characteristics provided by a user.
+user.provided.identifiable.childrens,Children's Data,user.provided.identifable,Data relating to children.
+user.provided.identifiable.contact,Provided Contact Data,user.provided.identifable,User provided contact data for purposes other than account management.
+user.provided.identifiable.contact.city,User Provided City,user.provided.identifable.contact,User's city level address data.
+user.provided.identifiable.contact.country,User Provided Country,user.provided.identifable.contact,User's country level address data.
+user.provided.identifiable.contact.email,User Provided Email,user.provided.identifable.contact,User's provided email address.
+user.provided.identifiable.contact.phone_number,User Provided Phone Number,user.provided.identifable.contact,User's phone number.
+user.provided.identifiable.contact.postal_code,User Provided Postal Code,user.provided.identifable.contact,User's postal code.
+user.provided.identifiable.contact.state,User Provided State,user.provided.identifable.contact,User's state level address data.
+user.provided.identifiable.contact.street,User Provided Street,user.provided.identifable.contact,User's street level address data.
+user.provided.identifiable.credentials,Credentials,user.provided.identifable,User provided authentication data.
+user.provided.identifiable.credentials.biometric_credentials,Biometric Credentials,user.provided.identifable.credentials,Credentials for system authentication.
+user.provided.identifiable.credentials.password,Password,user.provided.identifable.credentials,Password for system authentication.
+user.provided.identifiable.date_of_birth,Date of Birth,user.provided.identifable,User's date of birth.
+user.provided.identifiable.financial,Financial Data,user.provided.identifable,Payment data and financial history.
+user.provided.identifiable.financial.account_number,User Provided Financial Account Number,user.provided.identifable.financial,"User's account number for a payment card, bank account, or other financial system."
+user.provided.identifiable.gender,User Provided Gender,user.provided.identifable,Gender of an individual.
+user.provided.identifiable.genetic,Genetic Data,user.provided.identifable,Data about the genetic makeup provided by a user.
+user.provided.identifiable.government_id,Government ID,user.provided.identifable,State provided identification data.
+user.provided.identifiable.government_id.drivers_license_number,Driver's License Number,user.provided.identifable.government_id,State issued driving identification number.
+user.provided.identifiable.government_id.national_identification_number,National Identification Number,user.provided.identifable.government_id,State issued personal identification number.
+user.provided.identifiable.government_id.passport_number,Passport Number,user.provided.identifable.government_id,State issued passport data.
+user.provided.identifiable.health_and_medical,Health and Medical Data,user.provided.identifable,Health records or individual's personal medical data.
+user.provided.identifiable.job_title,Job Title,user.provided.identifable,Professional data.
+user.provided.identifiable.name,Name,user.provided.identifable,User's real name.
+user.provided.identifiable.non_specific_age,User Provided Non-Specific Age,user.provided.identifable,Age range data.
+user.provided.identifiable.political_opinion,Political Opinion,user.provided.identifable,Data related to the individual's political opinions.
+user.provided.identifiable.race,User Provided Race,user.provided.identifable,Racial or ethnic origin data.
+user.provided.identifiable.religious_belief,User Provided Religious Belief,user.provided.identifable,Religion or religious belief.
+user.provided.identifiable.sexual_orientation,User Provided Sexual Orientation,user.provided.identifable,Personal sex life or sexual data.
+user.provided.identifiable.workplace,User Provided Workplace,user.provided.identifable,Organization of employment.
+user.provided.nonidentifiable,User Provided Non-Identifiable Data,user,Data provided or created directly by a user that is not identifiable.

--- a/data_categories.csv
+++ b/data_categories.csv
@@ -20,7 +20,7 @@ user.derived.identifiable,Derived User Identifiable Data,user.derived,"Derived d
 user.derived.identifiable.biometric_health,Biometric Health Data,user.derived.identifiable,Encoded characteristic collected about a user.
 user.derived.identifiable.browsing_history,Browsing History,user.derived.identifiable,Content browsing history of a user.
 user.derived.identifiable.demographic,Demographic Data,user.derived.identifiable,Demographic data about a user.
-user.derived.identifiable.derived_contact,Derived Contact Data,user.derived.identifiable,Contact data collected about a user.
+user.derived.identifiable.contact,Derived Contact Data,user.derived.identifiable,Contact data collected about a user.
 user.derived.identifiable.device,Device Data,user.derived.identifiable,"Data related to a user's device, configuration and setting."
 user.derived.identifiable.device.cookie_id,Cookie ID,user.derived.identifiable.device,Cookie unique identification number.
 user.derived.identifiable.device.device_id,Device ID,user.derived.identifiable.device,Device unique identification number.

--- a/data_categories.yml
+++ b/data_categories.yml
@@ -1,373 +1,310 @@
 data-category:
-  # User Provided Data
-  - fidesKey: user_provided_data
-    name: "User Provided Data"
-    description: "Data provided or created directly by a user of the system."
+- fidesKey: account
+  name: Account Data
+  parentKey: data_category
+  description: Data related to a system account.
+- fidesKey: account.contact
+  name: Account Contact Data
+  parentKey: account
+  description: Contact data related to a system account.
+- fidesKey: account.contact.city
+  name: Account City
+  parentKey: account.contact
+  description: Account's city level address data.
+- fidesKey: account.contact.country
+  name: Account Country
+  parentKey: account.contact
+  description: Account's country level address data.
+- fidesKey: account.contact.email
+  name: Account Email
+  parentKey: account.contact
+  description: Account's email address.
+- fidesKey: account.contact.phone_number
+  name: Account Phone Number
+  parentKey: account.contact
+  description: Account's phone number.
+- fidesKey: account.contact.postal_code
+  name: Account Postal Code
+  parentKey: account.contact
+  description: Account's postal code.
+- fidesKey: account.contact.state
+  name: Account State
+  parentKey: account.contact
+  description: Account's state level address data.
+- fidesKey: account.contact.street
+  name: Account Street
+  parentKey: account.contact
+  description: Account's street level address.
+- fidesKey: account.payment
+  name: Payment Data
+  parentKey: account
+  description: Payment data related to system account.
+- fidesKey: account.payment.financial_account_number
+  name: Account Payment Financial Account Number
+  parentKey: account.payment
+  description: Financial account number for an account's payment card, bank account, or other financial system.
+- fidesKey: system
+  name: System Data
+  parentKey: data_category
+  description: Data unique to, and under control of the system.
+- fidesKey: system.authentication
+  name: Authentication Data
+  parentKey: system
+  description: Data used to manage access to the system.
+- fidesKey: system.operations
+  name: Operations Data
+  parentKey: system
+  description: Data used for system operations.
+- fidesKey: user
+  name: User Data
+  parentKey: data_category
+  description: Data related to the user of the system, either provided directly or derived based on their usage.
+- fidesKey: user.derived
+  name: Derived Data
+  parentKey: user
+  description: Data derived from user provided data or as a result of user actions in the system.
+- fidesKey: user.derived.identifiable
+  name: Derived User Identifiable Data
+  parentKey: user.derived
+  description: Derived data that is linked to, or identifies a user.
+- fidesKey: user.derived.identifiable.biometric_health
+  name: Biometric Health Data
+  parentKey: user.derived.identifiable
+  description: Encoded characteristic collected about a user.
+- fidesKey: user.derived.identifiable.browsing_history
+  name: Browsing History
+  parentKey: user.derived.identifiable
+  description: Content browsing history of a user.
+- fidesKey: user.derived.identifiable.demographic
+  name: Demographic Data
+  parentKey: user.derived.identifiable
+  description: Demographic data about a user.
+- fidesKey: user.derived.identifiable.derived_contact
+  name: Derived Contact Data
+  parentKey: user.derived.identifiable
+  description: Contact data collected about a user.
+- fidesKey: user.derived.identifiable.device
+  name: Device Data
+  parentKey: user.derived.identifiable
+  description: Data related to a user's device, configuration and setting.
+- fidesKey: user.derived.identifiable.device.cookie_id
+  name: Cookie ID
+  parentKey: user.derived.identifiable.device
+  description: Cookie unique identification number.
+- fidesKey: user.derived.identifiable.device.device_id
+  name: Device ID
+  parentKey: user.derived.identifiable.device
+  description: Device unique identification number.
+- fidesKey: user.derived.identifiable.device.ip_address
+  name: IP Address
+  parentKey: user.derived.identifiable.device
+  description: Unique identifier related to device connection.
+- fidesKey: user.derived.identifiable.gender
+  name: Derived Gender
+  parentKey: user.derived.identifiable
+  description: Gender of an individual.
+- fidesKey: user.derived.identifiable.location
+  name: Location Data
+  parentKey: user.derived.identifiable
+  description: Records of the location of a user.
+- fidesKey: user.derived.identifiable.media_consumption
+  name: Media Consumption Data
+  parentKey: user.derived.identifiable
+  description: Media type consumption data of a user.
+- fidesKey: user.derived.identifiable.non_specific_age
+  name: Derived Non-Specific Age
+  parentKey: user.derived.identifiable
+  description: Age range data.
+- fidesKey: user.derived.identifiable.observed
+  name: Observed Data
+  parentKey: user.derived.identifiable
+  description: Data collected through observation of use of the system.
+- fidesKey: user.derived.identifiable.profiling
+  name: Profiling Data
+  parentKey: user.derived.identifiable
+  description: Preference and interest data about a user.
+- fidesKey: user.derived.identifiable.race
+  name: Derived Race
+  parentKey: user.derived.identifiable
+  description: Racial or ethnic origin data.
+- fidesKey: user.derived.identifiable.religious_belief
+  name: Derived Religious Belief
+  parentKey: user.derived.identifiable
+  description: Religion or religious belief.
+- fidesKey: user.derived.identifiable.search_history
+  name: Search History
+  parentKey: user.derived.identifiable
+  description: Records of search history and queries of a user.
+- fidesKey: user.derived.identifiable.sexual_orientation
+  name: Derived Sexual Orientation
+  parentKey: user.derived.identifiable
+  description: Personal sex life or sexual data.
+- fidesKey: user.derived.identifiable.social
+  name: Social Data
+  parentKey: user.derived.identifiable
+  description: Social activity and interaction data.
+- fidesKey: user.derived.identifiable.telemetry
+  name: Telemetry Data
+  parentKey: user.derived.identifiable
+  description: User identifiable measurement data from system sensors and monitoring.
+- fidesKey: user.derived.identifiable.unique_id
+  name: Unique ID
+  parentKey: user.derived.identifiable
+  description: Unique identifier for a user assigned through system use.
+- fidesKey: user.derived.identifiable.user_sensor
+  name: User Sensor Data
+  parentKey: user.derived.identifiable
+  description: Measurement data derived about a user's environment through system use.
+- fidesKey: user.derived.identifiable.organization
+  name: Organization Identifiable Data
+  parentKey: user.derived
+  description: Derived data that is linked to, or identifies an organization.
+- fidesKey: user.derived.identifiable.workplace
+  name: Derived Workplace
+  parentKey: user.derived.identifiable
+  description: Organization of employment.
+- fidesKey: user.derived.nonidentifiable
+  name: Derived User Non-Identifiable Data
+  parentKey: user.derived.nonidentifiable
+  description: Non-user identifiable data derived related to a user as a result of user actions in the system.
+- fidesKey: user.derived.nonidentifiable.sensor
+  name: Sensor Data
+  parentKey: user.derived.nonidentifiable
+  description: Non-user identifiable measurement data derived from sensors and monitoring systems.
+- fidesKey: user.provided
+  name: User Provided Data
+  parentKey: user
+  description: Data provided or created directly by a user of the system.
+- fidesKey: user.provided.identifiable
+  name: User Provided Identifiable Data
+  parentKey: user
+  description: Data provided or created directly by a user that is linked to or identifies a user.
+- fidesKey: user.provided.identifiable.biometric
+  name: Biometric Data
+  parentKey: user.provided.identifable
+  description: Encoded characteristics provided by a user.
+- fidesKey: user.provided.identifiable.childrens
+  name: Children's Data
+  parentKey: user.provided.identifable
+  description: Data relating to children.
+- fidesKey: user.provided.identifiable.contact
+  name: Provided Contact Data
+  parentKey: user.provided.identifable
+  description: User provided contact data for purposes other than account management.
+- fidesKey: user.provided.identifiable.contact.city
+  name: User Provided City
+  parentKey: user.provided.identifable.contact
+  description: User's city level address data.
+- fidesKey: user.provided.identifiable.contact.country
+  name: User Provided Country
+  parentKey: user.provided.identifable.contact
+  description: User's country level address data.
+- fidesKey: user.provided.identifiable.contact.email
+  name: User Provided Email
+  parentKey: user.provided.identifable.contact
+  description: User's provided email address.
+- fidesKey: user.provided.identifiable.contact.phone_number
+  name: User Provided Phone Number
+  parentKey: user.provided.identifable.contact
+  description: User's phone number.
+- fidesKey: user.provided.identifiable.contact.postal_code
+  name: User Provided Postal Code
+  parentKey: user.provided.identifable.contact
+  description: User's postal code.
+- fidesKey: user.provided.identifiable.contact.state
+  name: User Provided State
+  parentKey: user.provided.identifable.contact
+  description: User's state level address data.
+- fidesKey: user.provided.identifiable.contact.street
+  name: User Provided Street
+  parentKey: user.provided.identifable.contact
+  description: User's street level address data.
+- fidesKey: user.provided.identifiable.credentials
+  name: Credentials
+  parentKey: user.provided.identifable
+  description: User provided authentication data.
+- fidesKey: user.provided.identifiable.credentials.biometric_credentials
+  name: Biometric Credentials
+  parentKey: user.provided.identifable.credentials
+  description: Credentials for system authentication.
+- fidesKey: user.provided.identifiable.credentials.password
+  name: Password
+  parentKey: user.provided.identifable.credentials
+  description: Password for system authentication.
+- fidesKey: user.provided.identifiable.date_of_birth
+  name: Date of Birth
+  parentKey: user.provided.identifable
+  description: User's date of birth.
+- fidesKey: user.provided.identifiable.financial
+  name: Financial Data
+  parentKey: user.provided.identifable
+  description: Payment data and financial history.
+- fidesKey: user.provided.identifiable.financial.account_number
+  name: User Provided Financial Account Number
+  parentKey: user.provided.identifable.financial
+  description: User's account number for a payment card, bank account, or other financial system.
+- fidesKey: user.provided.identifiable.gender
+  name: User Provided Gender
+  parentKey: user.provided.identifable
+  description: Gender of an individual.
+- fidesKey: user.provided.identifiable.genetic
+  name: Genetic Data
+  parentKey: user.provided.identifable
+  description: Data about the genetic makeup provided by a user.
+- fidesKey: user.provided.identifiable.government_id
+  name: Government ID
+  parentKey: user.provided.identifable
+  description: State provided identification data.
+- fidesKey: user.provided.identifiable.government_id.drivers_license_number
+  name: Driver's License Number
+  parentKey: user.provided.identifable.government_id
+  description: State issued driving identification number.
+- fidesKey: user.provided.identifiable.government_id.national_identification_number
+  name: National Identification Number
+  parentKey: user.provided.identifable.government_id
+  description: State issued personal identification number.
+- fidesKey: user.provided.identifiable.government_id.passport_number
+  name: Passport Number
+  parentKey: user.provided.identifable.government_id
+  description: State issued passport data.
+- fidesKey: user.provided.identifiable.health_and_medical
+  name: Health and Medical Data
+  parentKey: user.provided.identifable
+  description: Health records or individual's personal medical data.
+- fidesKey: user.provided.identifiable.job_title
+  name: Job Title
+  parentKey: user.provided.identifable
+  description: Professional data.
+- fidesKey: user.provided.identifiable.name
+  name: Name
+  parentKey: user.provided.identifable
+  description: User's real name.
+- fidesKey: user.provided.identifiable.non_specific_age
+  name: User Provided Non-Specific Age
+  parentKey: user.provided.identifable
+  description: Age range data.
+- fidesKey: user.provided.identifiable.political_opinion
+  name: Political Opinion
+  parentKey: user.provided.identifable
+  description: Data related to the individual's political opinions.
+- fidesKey: user.provided.identifiable.race
+  name: User Provided Race
+  parentKey: user.provided.identifable
+  description: Racial or ethnic origin data.
+- fidesKey: user.provided.identifiable.religious_belief
+  name: User Provided Religious Belief
+  parentKey: user.provided.identifable
+  description: Religion or religious belief.
+- fidesKey: user.provided.identifiable.sexual_orientation
+  name: User Provided Sexual Orientation
+  parentKey: user.provided.identifable
+  description: Personal sex life or sexual data.
+- fidesKey: user.provided.identifiable.workplace
+  name: User Provided Workplace
+  parentKey: user.provided.identifable
+  description: Organization of employment.
+- fidesKey: user.provided.nonidentifiable
+  name: User Provided Non-Identifiable Data
+  parentKey: user
+  description: Data provided or created directly by a user that is not identifiable.
 
-  - fidesKey: credentials
-    name: "Credentials"
-    parentKey: user_provided_data
-    description: "User provided authentication data."
-
-  - fidesKey: name
-    name: "Name"
-    parentKey: user_provided_data
-    description: "User's real name."
-
-  - fidesKey: date_of_birth
-    name: "Date of Birth"
-    parentKey: user_provided_data
-    description: "User's date of birth."
-
-  - fidesKey: user_provided_gender
-    name: "User Provided Gender"
-    parentKey: user_provided_data
-    description: "Gender of an individual."
-
-  - fidesKey: user_provided_race
-    name: "User Provided Race"
-    parentKey: user_provided_data
-    description: "Racial or ethnic origin data."
-
-  - fidesKey: user_provided_sexual_orientation
-    name: "User Provided Sexual Orientation"
-    parentKey: user_provided_data
-    description: "Personal sex life or sexual information."
-
-  - fidesKey: user_provided_non_specific_age
-    name: "User Provided Non-Specific Age"
-    parentKey: user_provided_data
-    description: "Age range information."
-
-  - fidesKey: job_title
-    name: "Job Title"
-    parentKey: user_provided_data
-    description: "Professional information."
-
-  - fidesKey: user_provided_workplace
-    name: "User Provided Workplace"
-    parentKey: user_provided_data
-    description: "Organization of employment."
-
-  - fidesKey: user_provided_religious_belief
-    name: "User Provided Religious Belief"
-    parentKey: user_provided_data
-    description: "Religion or religious belief."
-
-  - fidesKey: provided_contact_information
-    name: "Provided Contact Information"
-    parentKey: user_provided_data
-    description: "User provided contact information for purposes other than account management."
-
-  - fidesKey: health_and_medical_data
-    name: "Health and Medical Data"
-    parentKey: user_provided_data
-    description: "Health records or individual's personal medical information."
-
-  - fidesKey: genetic_data
-    name: "Genetic Data"
-    parentKey: user_provided_data
-    description: "Data about the genetic makeup provided by a user."
-
-  - fidesKey: biometric_data
-    name: "Biometric Data"
-    parentKey: user_provided_data
-    description: "Encoded characteristics provided by a user."
-
-  - fidesKey: childrens_data
-    name: "Children's Data"
-    parentKey: user_provided_data
-    description: "Data relating to children."
-
-  - fidesKey: political_opinion
-    name: "Political Opinion"
-    parentKey: user_provided_data
-    description: "Data related to the individual's political opinions."
-
-  - fidesKey: financial_data
-    name: "Financial Data"
-    parentKey: user_provided_data
-    description: "Payment data and financial history."
-
-  - fidesKey: government_id
-    name: "Government ID"
-    parentKey: user_provided_data
-    description: "State provided identification information."
-
-  # User Provided Data -> Financial Data
-  - fidesKey: user_provided_financial_account_number
-    name: "User Provided Financial Account Number"
-    parentKey: financial_data
-    description: "User's account number for a payment card, bank account, or other financial system."
-
-  # User Provided Data -> Credentials
-  - fidesKey: password
-    name: "Password"
-    parentKey: credentials
-    description: "Password for system authentication."
-
-  - fidesKey: biometric_credentials
-    name: "Biometric Credentials"
-    parentKey: credentials
-    description: "Credentials for system authentication."
-
-  # User Provided Data -> Provided Contact Information
-  - fidesKey: user_provided_email
-    name: "User Provided Email"
-    parentKey: provided_contact_information
-    description: "User's provided email address."
-
-  - fidesKey: user_provided_street
-    name: "User Provided Street"
-    parentKey: provided_contact_information
-    description: "User's street level address information."
-
-  - fidesKey: user_provided_city
-    name: "User Provided City"
-    parentKey: provided_contact_information
-    description: "User's city level address information."
-
-  - fidesKey: user_provided_state
-    name: "User Provided State"
-    parentKey: provided_contact_information
-    description: "User's state level address information."
-
-  - fidesKey: user_provided_postal_code
-    name: "User Provided Postal Code"
-    parentKey: provided_contact_information
-    description: "User's postal code."
-
-  - fidesKey: user_provided_country
-    name: "User Provided Country"
-    parentKey: provided_contact_information
-    description: "User's country level address information."
-
-  - fidesKey: user_provided_phone_number
-    name: "User Provided Phone Number"
-    parentKey: provided_contact_information
-    description: "User's phone number."
-
-  # User Provided Data -> Government ID
-  - fidesKey: national_identification_number
-    name: "National Identification Number"
-    parentKey: government_id
-    description: "State issued personal identification number."
-
-  - fidesKey: drivers_license_number
-    name: "Driver's License Number"
-    parentKey: government_id
-    description: "State issued driving identification number."
-
-  - fidesKey: passport_number
-    name: "Passport Number"
-    parentKey: government_id
-    description: "State issued passport data."
-
-  # Derived Data
-  - fidesKey: derived_data
-    name: "Derived Data"
-    description: "Data derived from user provided data or as a result of user actions in the system."
-
-  - fidesKey: user_identifiable_data
-    name: "User Identifiable Data"
-    parentKey: derived_data
-    description: "Derived data that is linked to, or identifies a user."
-
-  - fidesKey: organization_identifiable_data
-    name: "Organization Identifiable Data"
-    parentKey: derived_data
-    description: "Derived data that is linked to, or identifies an organization."
-
-  - fidesKey: sensor_data
-    name: "Sensor Data"
-    parentKey: derived_data
-    description: "Non-user identifiable measurement data derived from sensors and monitoring systems."
-
-  # Derived Data -> User Identifiable Data
-  - fidesKey: telemetry_data
-    name: "Telemetry Data"
-    parentKey: user_identifiable_data
-    description: "User identifiable measurement data from system sensors and monitoring."
-
-  - fidesKey: device_data
-    name: "Device Data"
-    parentKey: user_identifiable_data
-    description: "Data related to a user's device, configuration and setting."
-
-  - fidesKey: observed_data
-    name: "Observed Data"
-    parentKey: user_identifiable_data
-    description: "Data collected through observation of use of the system."
-
-  - fidesKey: demographic_information
-    name: "Demographic Information"
-    parentKey: user_identifiable_data
-    description: "Demographic information about a user."
-
-  - fidesKey: profiling_data
-    name: "Profiling Data"
-    parentKey: user_identifiable_data
-    description: "Preference and interest information about a user."
-
-  - fidesKey: media_consumption_data
-    name: "Media Consumption Data"
-    parentKey: user_identifiable_data
-    description: "Media type consumption information of a user."
-
-  - fidesKey: browsing_history
-    name: "Browsing History"
-    parentKey: user_identifiable_data
-    description: "Content browsing history of a user."
-
-  - fidesKey: search_history
-    name: "Search History"
-    parentKey: user_identifiable_data
-    description: "Records of search history and queries of a user."
-
-  - fidesKey: location_data
-    name: "Location Data"
-    parentKey: user_identifiable_data
-    description: "Records of the location of a user."
-
-  - fidesKey: social_data
-    name: "Social Data"
-    parentKey: user_identifiable_data
-    description: "Social activity and interaction data."
-
-  - fidesKey: biometric_health_data
-    name: "Biometric Health Data"
-    parentKey: user_identifiable_data
-    description: "Encoded characteristic collected about a user."
-
-  - fidesKey: derived_contact_data
-    name: "Derived Contact Data"
-    parentKey: user_identifiable_data
-    description: "Contact information collected about a user."
-
-  - fidesKey: user_sensor_data
-    name: "User Sensor Data"
-    parentKey: user_identifiable_data
-    description: "Measurement data derived about a user's environment through system use."
-
-  - fidesKey: derived_gender
-    name: "Derived Gender"
-    parentKey: user_identifiable_data
-    description: "Gender of an individual."
-
-  - fidesKey: derived_race
-    name: "Derived Race"
-    parentKey: user_identifiable_data
-    description: "Racial or ethnic origin data."
-
-  - fidesKey: derived_sexual_orientation
-    name: "Derived Sexual Orientation"
-    parentKey: user_identifiable_data
-    description: "Personal sex life or sexual information."
-
-  - fidesKey: derived_non_specific_age
-    name: "Derived Non-Specific Age"
-    parentKey: user_identifiable_data
-    description: "Age range information."
-
-  - fidesKey: derived_workplace
-    name: "Derived Workplace"
-    parentKey: user_identifiable_data
-    description: "Organization of employment."
-
-  - fidesKey: derived_religious_belief
-    name: "Derived Religious Belief"
-    parentKey: user_identifiable_data
-    description: "Religion or religious belief."
-
-  - fidesKey: unique_id
-    name: "Unique ID"
-    parentKey: user_identifiable_data
-    description: "Unique identifier for a user assigned through system use."
-
-  # Derived Data -> Device Data
-  - fidesKey: device_id
-    name: "Device ID"
-    parentKey: device_data
-    description: "Device unique identification number."
-
-  - fidesKey: cookie_id
-    name: "Cookie ID"
-    parentKey: device_data
-    description: "Cookie unique identification number."
-
-  - fidesKey: ip_address
-    name: "IP Address"
-    parentKey: device_data
-    description: "Unique identifier related to device connection."
-
-  # System Data
-  - fidesKey: system_data
-    name: "System Data"
-    description: "Data unique to, and under control of the system."
-
-  - fidesKey: authentication_data
-    name: "Authentication Data"
-    parentKey: system_data
-    description: "Data used to manage access to the system."
-
-  - fidesKey: operations_data
-    name: "Operations Data"
-    parentKey: system_data
-    description: "Data used for system operations."
-
-  # Account Data
-  - fidesKey: account_data
-    name: "Account Data"
-    description: "Data unique to, and under control of the system"
-
-  - fidesKey: payment_information
-    name: "Payment Information"
-    parentKey: account_data
-    description: "Payment data related to user's account."
-
-  - fidesKey: account_contact_information
-    name: "Account Contact Information"
-    parentKey: account_data
-    description: "Account data related to user contact information."
-
-  # Account Data -> Account Contact Information
-  - fidesKey: account_email
-    name: "Account Email"
-    parentKey: account_contact_information
-    description: "User account's email address."
-
-  - fidesKey: account_street
-    name: "Account Street"
-    parentKey: account_contact_information
-    description: "User account's street level address."
-
-  - fidesKey: account_city
-    name: "Account City"
-    parentKey: account_contact_information
-    description: "User's city level address information."
-
-  - fidesKey: account_state
-    name: "Account State"
-    parentKey: account_contact_information
-    description: "User's state level address information."
-
-  - fidesKey: account_postal_code
-    name: "Account Postal Code"
-    parentKey: account_contact_information
-    description: "User's postal code."
-
-  - fidesKey: account_country
-    name: "Account Country"
-    parentKey: account_contact_information
-    description: "User's country level address information."
-
-  - fidesKey: account_phone_number
-    name: "Account Phone Number"
-    parentKey: account_contact_information
-    description: "User's phone number."
-
-  # Account Data -> Payment Information
-  - fidesKey: accounts_financial_account_number
-    name: "Account's Financial Account Number"
-    parentKey: payment_information
-    description: "User's account number for a payment card, bank account, or other financial system."

--- a/scripts/convert_data_categories_csv_format.py
+++ b/scripts/convert_data_categories_csv_format.py
@@ -1,0 +1,33 @@
+"""
+Re-create the YAML data category taxonomy from a CSV file. Used when we have to
+edit the CSV file directly instead of the YAML source.
+"""
+import yaml
+import json
+import csv
+
+CSV_FILE = "../data_categories.csv"
+
+if __name__ == "__main__":
+    with open(CSV_FILE, "r") as input_file:
+        print(f"Loading CSV from {CSV_FILE}...")
+        csv_reader = csv.reader(input_file, delimiter=',')
+        yaml_dict = { "data-category": [] }
+        line_no = 0
+        for row in csv_reader:
+            line_no += 1
+            if line_no <= 2:
+                continue
+            node = {
+                "fidesKey": row[0],
+                "name": row[1],
+                "parentKey": row[2],
+                "description": row[3]
+            }
+            yaml_dict["data-category"].append(node)
+
+        yaml_filename = CSV_FILE.replace("csv", "yml")
+        with open(yaml_filename, "w") as yaml_file:
+            print(f"Writing YAML to {yaml_filename}...")
+            yaml_str = yaml.dump(yaml_dict, width=120, sort_keys=False)
+            print(yaml_str, file=yaml_file)


### PR DESCRIPTION
This makes several large edits to the taxonomy:
1. Replaces all existing `fidesKeys` with fully-qualified, dot-notation paths like `user.provided.contact.email` instead of the previous `user_provided_email` (which was in the overall path `user_provided_data > provided_contact_information > user_provided_email`)
2. Add a new top-level `user` category, which is the new parent for the previous `user_provided_data` and `derived_data` categories. This makes the top-level categories all related to different types of "owners"
3. Introduce `identifiable` and `nonidentifiable` sub-categories to the `user.provided` and `user.derived` categories, to give a clear boundary to where identifiable data is located
4. Various miscellaneous key renames for conciseness, now that we are providing the fully-qualified path (e.g. instead of `contact_information` use `contact`, or instead of `social_data` use `social`

The intent here is to make the taxonomy a lot easier to read and consume without a heavy amount of training up front.