### PR TITLE
Proposed Dot Notation for Data use Cases

### DIFF
--- a/data_categories.csv
+++ b/data_categories.csv
@@ -67,7 +67,7 @@ user.provided.identifiable.government_id,Government ID,user.provided.identifiabl
 user.provided.identifiable.government_id.drivers_license_number,Driver's License Number,user.provided.identifiable.government_id,State issued driving identification number.
 user.provided.identifiable.government_id.national_identification_number,National Identification Number,user.provided.identifiable.government_id,State issued personal identification number.
 user.provided.identifiable.government_id.passport_number,Passport Number,user.provided.identifiable.government_id,State issued passport data.
-user.provided.identifiable.health_and_medical,Health and Medical Data,user.provided.identifiable,Health records or individual's personal medical data.
+user.provided.identifiable.health_and_medical,Health and Medical Data,user.provided.identifiable,Health records or individual's personal medical information.
 user.provided.identifiable.job_title,Job Title,user.provided.identifiable,Professional data.
 user.provided.identifiable.name,Name,user.provided.identifiable,User's real name.
 user.provided.identifiable.non_specific_age,User Provided Non-Specific Age,user.provided.identifiable,Age range data.

--- a/data_categories.json
+++ b/data_categories.json
@@ -403,7 +403,7 @@
             "fides_key": "user.provided.identifiable.health_and_medical",
             "name": "Health and Medical Data",
             "parent_key": "user.provided.identifiable",
-            "description": "Health records or individual's personal medical data."
+            "description": "Health records or individual's personal medical information."
         },
         {
             "fides_key": "user.provided.identifiable.job_title",

--- a/data_categories.yml
+++ b/data_categories.yml
@@ -1,4 +1,5 @@
 data_category:
+  # Account Data -- Data related to an account in the system.
   - fides_key: account
     name: Account Data
     description: Data related to a system account.
@@ -53,6 +54,7 @@ data_category:
     parent_key: account.payment
     description: Financial account number for an account's payment card, bank account, or other financial system.
 
+  # System Data -- Data unique to and under management of the system.
   - fides_key: system
     name: System Data
     description: Data unique to, and under control of the system.
@@ -67,15 +69,18 @@ data_category:
     parent_key: system
     description: Data used for system operations.
 
+  # User Data -- Data related to an individual user of the system.
   - fides_key: user
     name: User Data
     description: Data related to the user of the system, either provided directly or derived based on their usage.
 
+  # User Derived Data -- Data related to an individual, derived from their actions in the system.
   - fides_key: user.derived
     name: Derived Data
     parent_key: user
     description: Data derived from user provided data or as a result of user actions in the system.
 
+  # User Derived, Identifiable Data -- Data derived from a users actions that identifies them.
   - fides_key: user.derived.identifiable
     name: Derived User Identifiable Data
     parent_key: user.derived
@@ -201,6 +206,7 @@ data_category:
     parent_key: user.derived.identifiable
     description: Organization of employment.
 
+  # User Derived, Non-identifiable Data -- Data derived from a users actions that does not identify them.
   - fides_key: user.derived.nonidentifiable
     name: Derived User Non-Identifiable Data
     parent_key: user.derived
@@ -211,11 +217,13 @@ data_category:
     parent_key: user.derived.nonidentifiable
     description: Non-user identifiable measurement data derived from sensors and monitoring systems.
 
+  # User Provided Data -- Data related to an individual, provided directly by the individual.
   - fides_key: user.provided
     name: User Provided Data
     parent_key: user
     description: Data provided or created directly by a user of the system.
 
+  # User Provided, Identifiable Data -- Data provided by a user that identifies them.
   - fides_key: user.provided.identifiable
     name: User Provided Identifiable Data
     parent_key: user.provided
@@ -334,7 +342,7 @@ data_category:
   - fides_key: user.provided.identifiable.health_and_medical
     name: Health and Medical Data
     parent_key: user.provided.identifiable
-    description: Health records or individual's personal medical data.
+    description: Health records or individual's personal medical information.
 
   - fides_key: user.provided.identifiable.job_title
     name: Job Title
@@ -376,6 +384,7 @@ data_category:
     parent_key: user.provided.identifiable
     description: Organization of employment.
 
+  # User Provided, Non-identifiable Data -- Data provided by a user that does not identify them.
   - fides_key: user.provided.nonidentifiable
     name: User Provided Non-Identifiable Data
     parent_key: user.provided

--- a/data_qualifiers.csv
+++ b/data_qualifiers.csv
@@ -1,7 +1,7 @@
-fides_key,name,parent_key
-data_qualifier,Data Qualifier,
-identified_data,Identified Data,data_qualifier
-pseudonymized_data,Pseudonymized Data,data_qualifier
-unlinked_pseudonymized_data,Unlinked Pseudonymized Data,data_qualifier
-anonymized_data,Anonymized Data,data_qualifier
-aggregated_data,Aggregated Data,data_qualifier
+fides_key,name,parent_key,description
+data_qualifier,Data Qualifier,,
+identified_data,Identified Data,data_qualifier,Data that directly identifies an individual.
+pseudonymized_data,Pseudonymized Data,data_qualifier,"Data for which all identifiers have been substituted with unrelated values, rendering the individual unidentifiable and cannot be reasonably reversed other than by the party that performed the pseudonymization."
+unlinked_pseudonymized_data,Unlinked Pseudonymized Data,data_qualifier,"Data for which all identifiers have been substituted with unrelated values and linkages broken such that it may not be reversed, even by the party that performed the pseudonymization."
+anonymized_data,Anonymized Data,data_qualifier,Data where all attributes have been sufficiently altered that the individaul cannot be reidentified by this data or in combination with other datasets.
+aggregated_data,Aggregated Data,data_qualifier,Statistical data that does not contain individually identifying information but includes information about groups of individuals that renders individual identification impossible.

--- a/data_qualifiers.json
+++ b/data_qualifiers.json
@@ -2,23 +2,28 @@
     "data_qualifier": [
         {
             "fides_key": "identified_data",
-            "name": "Identified Data"
+            "name": "Identified Data",
+            "description": "Data that directly identifies an individual."
         },
         {
             "fides_key": "pseudonymized_data",
-            "name": "Pseudonymized Data"
+            "name": "Pseudonymized Data",
+            "description": "Data for which all identifiers have been substituted with unrelated values, rendering the individual unidentifiable and cannot be reasonably reversed other than by the party that performed the pseudonymization."
         },
         {
             "fides_key": "unlinked_pseudonymized_data",
-            "name": "Unlinked Pseudonymized Data"
+            "name": "Unlinked Pseudonymized Data",
+            "description": "Data for which all identifiers have been substituted with unrelated values and linkages broken such that it may not be reversed, even by the party that performed the pseudonymization."
         },
         {
             "fides_key": "anonymized_data",
-            "name": "Anonymized Data"
+            "name": "Anonymized Data",
+            "description": "Data where all attributes have been sufficiently altered that the individaul cannot be reidentified by this data or in combination with other datasets."
         },
         {
             "fides_key": "aggregated_data",
-            "name": "Aggregated Data"
+            "name": "Aggregated Data",
+            "description": "Statistical data that does not contain individually identifying information but includes information about groups of individuals that renders individual identification impossible."
         }
     ]
 }

--- a/data_qualifiers.yml
+++ b/data_qualifiers.yml
@@ -1,15 +1,20 @@
 data_qualifier:
   - fides_key: identified_data
     name: Identified Data
+    description: Data that directly identifies an individual.
 
   - fides_key: pseudonymized_data
     name: Pseudonymized Data
+    description: Data for which all identifiers have been substituted with unrelated values, rendering the individual unidentifiable and cannot be reasonably reversed other than by the party that performed the pseudonymization.
 
   - fides_key: unlinked_pseudonymized_data
     name: Unlinked Pseudonymized Data
+    description: Data for which all identifiers have been substituted with unrelated values and linkages broken such that it may not be reversed, even by the party that performed the pseudonymization.
 
   - fides_key: anonymized_data
     name: Anonymized Data
+    description: Data where all attributes have been sufficiently altered that the individaul cannot be reidentified by this data or in combination with other datasets.
 
   - fides_key: aggregated_data
     name: Aggregated Data
+    description: Statistical data that does not contain individually identifying information but includes information about groups of individuals that renders individual identification impossible.

--- a/data_subjects.csv
+++ b/data_subjects.csv
@@ -1,17 +1,17 @@
-fides_key,name,parent_key
-data_subject,Data Subject,
-anonymous_user,Anonymous User,data_subject
-citizen_voter,Citizen Voter,data_subject
-commuter,Commuter,data_subject
-consultant,Consultant,data_subject
-customer,Custom,data_subject
-employee,Employee,data_subject
-job_applicant,Job Applicant,data_subject
-next_of_kin,Next of Kin,data_subject
-passenger,Passenger,data_subject
-patient,Patient,data_subject
-prospect,Prospect,data_subject
-shareholder,Shareholder,data_subject
-supplier_vendor,Supplier/Vendor,data_subject
-trainee,Trainee,data_subject
-visitor,Visitor,data_subject
+fides_key,name,parent_key,description
+data_subject,Data Subject,,
+anonymous_user,Anonymous User,data_subject,An individual that is unidentifiable to the systems. Note - This should only be applied to truly anonymous users where there is no risk of re-identification
+citizen_voter,Citizen Voter,data_subject,An individual registered to voter with a state or authority.
+commuter,Commuter,data_subject,An individual that is traveling or transiting in the context of location tracking.
+consultant,Consultant,data_subject,An individual employed in a consultative/temporary capacity by the organization.
+customer,Custom,data_subject,An individual or other organization that purchases goods or services from the organization.
+employee,Employee,data_subject,An individual employed by the organization.
+job_applicant,Job Applicant,data_subject,An individual applying for employment to the organization.
+next_of_kin,Next of Kin,data_subject,A relative of any other individual subject where such a relationship is known.
+passenger,Passenger,data_subject,An individual traveling on some means of provided transport.
+patient,Patient,data_subject,An individual identified for the purposes of any medical care.
+prospect,Prospect,data_subject,An individual or organization to whom an organization is selling goods or services.
+shareholder,Shareholder,data_subject,An individual or organization that holds equity in the organization.
+supplier_vendor,Supplier/Vendor,data_subject,An individual or organization that provides services or goods to the organization.
+trainee,Trainee,data_subject,An individual undergoing training by the organization.
+visitor,Visitor,data_subject,An individual visiting a location.

--- a/data_subjects.json
+++ b/data_subjects.json
@@ -2,63 +2,78 @@
     "data_subject": [
         {
             "fides_key": "anonymous_user",
-            "name": "Anonymous User"
+            "name": "Anonymous User",
+            "description": "An individual that is unidentifiable to the systems. Note - This should only be applied to truly anonymous users where there is no risk of re-identification"
         },
         {
             "fides_key": "citizen_voter",
-            "name": "Citizen Voter"
+            "name": "Citizen Voter",
+            "description": "An individual registered to voter with a state or authority."
         },
         {
             "fides_key": "commuter",
-            "name": "Commuter"
+            "name": "Commuter",
+            "description": "An individual that is traveling or transiting in the context of location tracking."
         },
         {
             "fides_key": "consultant",
-            "name": "Consultant"
+            "name": "Consultant",
+            "description": "An individual employed in a consultative/temporary capacity by the organization."
         },
         {
             "fides_key": "customer",
-            "name": "Custom"
+            "name": "Custom",
+            "description": "An individual or other organization that purchases goods or services from the organization."
         },
         {
             "fides_key": "employee",
-            "name": "Employee"
+            "name": "Employee",
+            "description": "An individual employed by the organization."
         },
         {
             "fides_key": "job_applicant",
-            "name": "Job Applicant"
+            "name": "Job Applicant",
+            "description": "An individual applying for employment to the organization."
         },
         {
             "fides_key": "next_of_kin",
-            "name": "Next of Kin"
+            "name": "Next of Kin",
+            "description": "A relative of any other individual subject where such a relationship is known."
         },
         {
             "fides_key": "passenger",
-            "name": "Passenger"
+            "name": "Passenger",
+            "description": "An individual traveling on some means of provided transport."
         },
         {
             "fides_key": "patient",
-            "name": "Patient"
+            "name": "Patient",
+            "description": "An individual identified for the purposes of any medical care."
         },
         {
             "fides_key": "prospect",
-            "name": "Prospect"
+            "name": "Prospect",
+            "description": "An individual or organization to whom an organization is selling goods or services."
         },
         {
             "fides_key": "shareholder",
-            "name": "Shareholder"
+            "name": "Shareholder",
+            "description": "An individual or organization that holds equity in the organization."
         },
         {
             "fides_key": "supplier_vendor",
-            "name": "Supplier/Vendor"
+            "name": "Supplier/Vendor",
+            "description": "An individual or organization that provides services or goods to the organization."
         },
         {
             "fides_key": "trainee",
-            "name": "Trainee"
+            "name": "Trainee",
+            "description": "An individual undergoing training by the organization."
         },
         {
             "fides_key": "visitor",
-            "name": "Visitor"
+            "name": "Visitor",
+            "description": "An individual visiting a location."
         }
     ]
 }

--- a/data_subjects.yml
+++ b/data_subjects.yml
@@ -1,45 +1,60 @@
 data_subject:
   - fides_key: anonymous_user
     name: Anonymous User
+    description: An individual that is unidentifiable to the systems. Note - This should only be applied to truly anonymous users where there is no risk of re-identification
 
   - fides_key: citizen_voter
     name: Citizen Voter
+    description: An individual registered to voter with a state or authority.
 
   - fides_key: commuter
     name: Commuter
+    description: An individual that is traveling or transiting in the context of location tracking.
 
   - fides_key: consultant
     name: Consultant
+    description: An individual employed in a consultative/temporary capacity by the organization.
 
   - fides_key: customer
     name: Custom
+    description: An individual or other organization that purchases goods or services from the organization.
 
   - fides_key: employee
     name: Employee
+    description: An individual employed by the organization.
 
   - fides_key: job_applicant
     name: Job Applicant
+    description: An individual applying for employment to the organization.
 
   - fides_key: next_of_kin
     name: Next of Kin
+    description: A relative of any other individual subject where such a relationship is known.
 
   - fides_key: passenger
     name: Passenger
+    description: An individual traveling on some means of provided transport.
 
   - fides_key: patient
     name: Patient
+    description: An individual identified for the purposes of any medical care.
 
   - fides_key: prospect
     name: Prospect
+    description: An individual or organization to whom an organization is selling goods or services.
 
   - fides_key: shareholder
     name: Shareholder
+    description: An individual or organization that holds equity in the organization.
 
   - fides_key: supplier_vendor
     name: Supplier/Vendor
+    description: An individual or organization that provides services or goods to the organization.
 
   - fides_key: trainee
     name: Trainee
+    description: An individual undergoing training by the organization.
 
   - fides_key: visitor
     name: Visitor
+    description: An individual visiting a location.

--- a/data_uses.csv
+++ b/data_uses.csv
@@ -1,17 +1,21 @@
 fides_key,name,parent_key,description
 data_use,Data Use,,
-provide_product_or_service,Provide the Product or Service,data_use,Use of specified data categories to provide the proposed service to the user.
-provide_product_or_service.support,Support the Product or Service,provide_product_or_service,Use of specified data categories to operate and protect the system in order to provide the service.
-provide_product_or_service.support_optimization,Support Optimization,provide_product_or_service,Use of specified data categories to ensure appropriate support for the service is being provided.
-provide_product_or_service.offer_upgrades,Offers of Product or Service Upgrades,provide_product_or_service,Offer upgrades or upsales such as increased capacity for the service based on monitoring of service usage.
-improve_product_or_service,Improve the Product or Service,data_use,Use specified data categories related to the user or system in order to improve the quality of the service.
-personalize_product_or_service,Personalize the Product or Service,data_use,Use of specified data categories for the purpose of personalizing the features or services of the application.
-marketing_advertising_or_promotion,"Marketing, Advertising or Promotion",data_use,The promotion of products or services targeted to users based on the the processing of user provided data in the system.
-marketing_advertising_or_promotion.first_party,First Party Advertising,marketing_advertising_or_promotion,The promotion of products or services targeting users based on processing of derviced data from prior use of the system.
-marketing_advertising_or_promotion.third_party,Third Party Advertising,marketing_advertising_or_promotion,The promotion of products or services targeting users based on processing of specific categories of data acquired from third party sources.
-marketing_advertising_or_promotion.first_party.contextual,First Party Contextual Advertising,marketing_advertising_or_promotion.first_party,The promotion of products or services targeted to users based on the processing of derived data from the users prior use of the services.
-marketing_advertising_or_promotion.first_party.personalized,First Party Personalized Advertising,marketing_advertising_or_promotion.first_party,The targeting and changing of promotional content based on processing of specific data categories from the user.
-marketing_advertising_or_promotion.third_party.personalized,Third Party Personalized Advertising,marketing_advertising_or_promotion.third_party,The targeting and changing of promotional content based on processing of specific categories of user data acquired from third party sources.
+provide,Provide the capability,data_use,"Provide, give, or make available the product, service, application or system."
+provide.system,System,provide,"The source system, product, service or application being provided to the user."
+provide.system.operations,System Operations,provide.system,Use of specified data categories to operate and protect the system in order to provide the service.
+provide.system.operations.support,Operations Support,provide.system.operations,Use of specified data categories to provide support for operation and protection of the system in order to provide the service.
+provide.system.operations.support.optimization,Support Optimization,provide.system.operations.support,Use of specified data categories to optimize and improve support operations in order to provide the service.
+provide.system.upgrades,Offer Upgrades,provide.system,Offer upgrades or upsales such as increased capacity for the service based on monitoring of service usage.
+improve,Improve the capability,data_use,"Improve the product, service, application or system."
+improve.system,System,improve,"The source system, product, service or application being improved."
+personalize,Personalize the capability,data_use,"Personalize the product, service, application or system."
+personalize.system,System,personalize,"The source system, product, service or application being personalized."
+advertising,"Advertising, Marketing or Promotion",data_use,The promotion of products or services targeted to users based on the the processing of user provided data in the system.
+advertising.first_party,First Party Advertising,advertising,The promotion of products or services targeting users based on processing of derviced data from prior use of the system.
+advertising.third_party,Third Party Advertising,advertising,The promotion of products or services targeting users based on processing of specific categories of data acquired from third party sources.
+advertising.first_party.contextual,First Party Contextual Advertising,advertising.first_party,The promotion of products or services targeted to users based on the processing of derived data from the users prior use of the services.
+advertising.first_party.personalized,First Party Personalized Advertising,advertising.first_party,The targeting and changing of promotional content based on processing of specific data categories from the user.
+advertising.third_party.personalized,Third Party Personalized Advertising,advertising.third_party,The targeting and changing of promotional content based on processing of specific categories of user data acquired from third party sources.
 third_party_sharing,Third Party Sharing,data_use,The transfer of specified data categories to third parties outside of the system/application's scope.
 third_party_sharing.payment_processing,Sharing for Processing Payments,third_party_sharing,Sharing of specified data categories with a third party for payment processing.
 third_party_sharing.personalized_advertising,Sharing for Personalized Advertising,third_party_sharing,Sharing of specified data categories for the purpose of marketing/advertising/promotion.

--- a/data_uses.csv
+++ b/data_uses.csv
@@ -1,20 +1,21 @@
-fides_key,name,parent_key
-data_use,Data Use,
-provide_product_or_service,Provide the Product or Service,data_use
-provide_product_or_service.support,Support the Product or Service,provide_product_or_service
-provide_product_or_service.support_optimization,Support Optimization,provide_product_or_service
-provide_product_or_service.offer_upgrades,Offers of Product or Service Upgrades,provide_product_or_service
-improve_product_or_service,Improve the Product or Service,data_use
-personalize_product_or_service,Personalize the Product or Service,data_use
-marketing_advertising_or_promotion,"Marketing, Advertising or Promotion",data_use
-marketing_advertising_or_promotion.first_party,First Party Advertising,marketing_advertising_or_promotion
-marketing_advertising_or_promotion.third_party,Third Party Advertising,marketing_advertising_or_promotion
-marketing_advertising_or_promotion.first_party.contextual,First Party Contextual Advertising,marketing_advertising_or_promotion.first_party
-marketing_advertising_or_promotion.first_party.personalized,First Party Personalized Advertising,marketing_advertising_or_promotion.first_party
-marketing_advertising_or_promotion.third_party.personalized,Third Party Personalized Advertising,marketing_advertising_or_promotion.third_party
-third_party_sharing,Third Party Sharing,data_use
-third_party_sharing.payment_processing,Sharing for Processing Payments,third_party_sharing
-third_party_sharing.personalized_advertising,Sharing for Personalized Advertising,third_party_sharing
-third_party_sharing.legal_obligation,Sharing for Legal Obligation,third_party_sharing
-collect,Collect,data_use
-train_ai_system,Train AI System,data_use
+fides_key,name,parent_key,description
+data_use,Data Use,,
+provide_product_or_service,Provide the Product or Service,data_use,Use of specified data categories to provide the proposed service to the user.
+provide_product_or_service.support,Support the Product or Service,provide_product_or_service,Use of specified data categories to operate and protect the system in order to provide the service.
+provide_product_or_service.support_optimization,Support Optimization,provide_product_or_service,Use of specified data categories to ensure appropriate support for the service is being provided.
+provide_product_or_service.offer_upgrades,Offers of Product or Service Upgrades,provide_product_or_service,Offer upgrades or upsales such as increased capacity for the service based on monitoring of service usage.
+improve_product_or_service,Improve the Product or Service,data_use,Use specified data categories related to the user or system in order to improve the quality of the service.
+personalize_product_or_service,Personalize the Product or Service,data_use,Use of specified data categories for the purpose of personalizing the features or services of the application.
+marketing_advertising_or_promotion,"Marketing, Advertising or Promotion",data_use,The promotion of products or services targeted to users based on the the processing of user provided data in the system.
+marketing_advertising_or_promotion.first_party,First Party Advertising,marketing_advertising_or_promotion,The promotion of products or services targeting users based on processing of derviced data from prior use of the system.
+marketing_advertising_or_promotion.third_party,Third Party Advertising,marketing_advertising_or_promotion,The promotion of products or services targeting users based on processing of specific categories of data acquired from third party sources.
+marketing_advertising_or_promotion.first_party.contextual,First Party Contextual Advertising,marketing_advertising_or_promotion.first_party,The promotion of products or services targeted to users based on the processing of derived data from the users prior use of the services.
+marketing_advertising_or_promotion.first_party.personalized,First Party Personalized Advertising,marketing_advertising_or_promotion.first_party,The targeting and changing of promotional content based on processing of specific data categories from the user.
+marketing_advertising_or_promotion.third_party.personalized,Third Party Personalized Advertising,marketing_advertising_or_promotion.third_party,The targeting and changing of promotional content based on processing of specific categories of user data acquired from third party sources.
+third_party_sharing,Third Party Sharing,data_use,The transfer of specified data categories to third parties outside of the system/application's scope.
+third_party_sharing.payment_processing,Sharing for Processing Payments,third_party_sharing,Sharing of specified data categories with a third party for payment processing.
+third_party_sharing.personalized_advertising,Sharing for Personalized Advertising,third_party_sharing,Sharing of specified data categories for the purpose of marketing/advertising/promotion.
+third_party_sharing.fraud_detection,Sharing for Fraud Detection,third_party_sharing,Sharing of specified data categories with a third party fo fraud prevention/detection.
+third_party_sharing.legal_obligation,Sharing for Legal Obligation,third_party_sharing,"Sharing of data for legal obligations, including contracts, applicable laws or regulations."
+collect,Collect,data_use,Collecting and storing data in order to use it for another purpose such as data training for ML.
+train_ai_system,Train AI System,data_use,"Training an AI system. Please note when this data use is specified, the method and degree to which a user may be directly identified in the resulting AI system should be appended."

--- a/data_uses.json
+++ b/data_uses.json
@@ -2,86 +2,110 @@
     "data_use": [
         {
             "fides_key": "provide_product_or_service",
-            "name": "Provide the Product or Service"
+            "name": "Provide the Product or Service",
+            "description": "Use of specified data categories to provide the proposed service to the user."
         },
         {
             "fides_key": "provide_product_or_service.support",
             "name": "Support the Product or Service",
-            "parent_key": "provide_product_or_service"
+            "parent_key": "provide_product_or_service",
+            "description": "Use of specified data categories to operate and protect the system in order to provide the service."
         },
         {
             "fides_key": "provide_product_or_service.support_optimization",
             "name": "Support Optimization",
-            "parent_key": "provide_product_or_service"
+            "parent_key": "provide_product_or_service",
+            "description": "Use of specified data categories to ensure appropriate support for the service is being provided."
         },
         {
             "fides_key": "provide_product_or_service.offer_upgrades",
             "name": "Offers of Product or Service Upgrades",
-            "parent_key": "provide_product_or_service"
+            "parent_key": "provide_product_or_service",
+            "description": "Offer upgrades or upsales such as increased capacity for the service based on monitoring of service usage."
         },
         {
             "fides_key": "improve_product_or_service",
-            "name": "Improve the Product or Service"
+            "name": "Improve the Product or Service",
+            "description": "Use specified data categories related to the user or system in order to improve the quality of the service."
         },
         {
             "fides_key": "personalize_product_or_service",
-            "name": "Personalize the Product or Service"
+            "name": "Personalize the Product or Service",
+            "description": "Use of specified data categories for the purpose of personalizing the features or services of the application."
         },
         {
             "fides_key": "marketing_advertising_or_promotion",
-            "name": "Marketing, Advertising or Promotion"
+            "name": "Marketing, Advertising or Promotion",
+            "description": "The promotion of products or services targeted to users based on the the processing of user provided data in the system."
         },
         {
             "fides_key": "marketing_advertising_or_promotion.first_party",
             "name": "First Party Advertising",
-            "parent_key": "marketing_advertising_or_promotion"
+            "parent_key": "marketing_advertising_or_promotion",
+            "description": "The promotion of products or services targeting users based on processing of derviced data from prior use of the system."
         },
         {
             "fides_key": "marketing_advertising_or_promotion.third_party",
             "name": "Third Party Advertising",
-            "parent_key": "marketing_advertising_or_promotion"
+            "parent_key": "marketing_advertising_or_promotion",
+            "description": "The promotion of products or services targeting users based on processing of specific categories of data acquired from third party sources."
         },
         {
             "fides_key": "marketing_advertising_or_promotion.first_party.contextual",
             "name": "First Party Contextual Advertising",
-            "parent_key": "marketing_advertising_or_promotion.first_party"
+            "parent_key": "marketing_advertising_or_promotion.first_party",
+            "description": "The promotion of products or services targeted to users based on the processing of derived data from the users prior use of the services."
         },
         {
             "fides_key": "marketing_advertising_or_promotion.first_party.personalized",
             "name": "First Party Personalized Advertising",
-            "parent_key": "marketing_advertising_or_promotion.first_party"
+            "parent_key": "marketing_advertising_or_promotion.first_party",
+            "description": "The targeting and changing of promotional content based on processing of specific data categories from the user."
         },
         {
             "fides_key": "marketing_advertising_or_promotion.third_party.personalized",
             "name": "Third Party Personalized Advertising",
-            "parent_key": "marketing_advertising_or_promotion.third_party"
+            "parent_key": "marketing_advertising_or_promotion.third_party",
+            "description": "The targeting and changing of promotional content based on processing of specific categories of user data acquired from third party sources."
         },
         {
             "fides_key": "third_party_sharing",
-            "name": "Third Party Sharing"
+            "name": "Third Party Sharing",
+            "description": "The transfer of specified data categories to third parties outside of the system/application's scope."
         },
         {
             "fides_key": "third_party_sharing.payment_processing",
             "name": "Sharing for Processing Payments",
-            "parent_key": "third_party_sharing"
+            "parent_key": "third_party_sharing",
+            "description": "Sharing of specified data categories with a third party for payment processing."
         },
         {
             "fides_key": "third_party_sharing.personalized_advertising",
             "name": "Sharing for Personalized Advertising",
-            "parent_key": "third_party_sharing"
+            "parent_key": "third_party_sharing",
+            "description": "Sharing of specified data categories for the purpose of marketing/advertising/promotion."
+        },
+        {
+            "fides_key": "third_party_sharing.fraud_detection",
+            "name": "Sharing for Fraud Detection",
+            "parent_key": "third_party_sharing",
+            "description": "Sharing of specified data categories with a third party fo fraud prevention/detection."
         },
         {
             "fides_key": "third_party_sharing.legal_obligation",
             "name": "Sharing for Legal Obligation",
-            "parent_key": "third_party_sharing"
+            "parent_key": "third_party_sharing",
+            "description": "Sharing of data for legal obligations, including contracts, applicable laws or regulations."
         },
         {
             "fides_key": "collect",
-            "name": "Collect"
+            "name": "Collect",
+            "description": "Collecting and storing data in order to use it for another purpose such as data training for ML."
         },
         {
             "fides_key": "train_ai_system",
-            "name": "Train AI System"
+            "name": "Train AI System",
+            "description": "Training an AI system. Please note when this data use is specified, the method and degree to which a user may be directly identified in the resulting AI system should be appended."
         }
     ]
 }

--- a/data_uses.json
+++ b/data_uses.json
@@ -1,71 +1,95 @@
 {
     "data_use": [
         {
-            "fides_key": "provide_product_or_service",
-            "name": "Provide the Product or Service",
-            "description": "Use of specified data categories to provide the proposed service to the user."
+            "fides_key": "provide",
+            "name": "Provide the capability",
+            "description": "Provide, give, or make available the product, service, application or system."
         },
         {
-            "fides_key": "provide_product_or_service.support",
-            "name": "Support the Product or Service",
-            "parent_key": "provide_product_or_service",
+            "fides_key": "provide.system",
+            "name": "System",
+            "parent_key": "provide",
+            "description": "The source system, product, service or application being provided to the user."
+        },
+        {
+            "fides_key": "provide.system.operations",
+            "name": "System Operations",
+            "parent_key": "provide.system",
             "description": "Use of specified data categories to operate and protect the system in order to provide the service."
         },
         {
-            "fides_key": "provide_product_or_service.support_optimization",
-            "name": "Support Optimization",
-            "parent_key": "provide_product_or_service",
-            "description": "Use of specified data categories to ensure appropriate support for the service is being provided."
+            "fides_key": "provide.system.operations.support",
+            "name": "Operations Support",
+            "parent_key": "provide.system.operations",
+            "description": "Use of specified data categories to provide support for operation and protection of the system in order to provide the service."
         },
         {
-            "fides_key": "provide_product_or_service.offer_upgrades",
-            "name": "Offers of Product or Service Upgrades",
-            "parent_key": "provide_product_or_service",
+            "fides_key": "provide.system.operations.support.optimization",
+            "name": "Support Optimization",
+            "parent_key": "provide.system.operations.support",
+            "description": "Use of specified data categories to optimize and improve support operations in order to provide the service."
+        },
+        {
+            "fides_key": "provide.system.upgrades",
+            "name": "Offer Upgrades",
+            "parent_key": "provide.system",
             "description": "Offer upgrades or upsales such as increased capacity for the service based on monitoring of service usage."
         },
         {
-            "fides_key": "improve_product_or_service",
-            "name": "Improve the Product or Service",
-            "description": "Use specified data categories related to the user or system in order to improve the quality of the service."
+            "fides_key": "improve",
+            "name": "Improve the capability",
+            "description": "Improve the product, service, application or system."
         },
         {
-            "fides_key": "personalize_product_or_service",
-            "name": "Personalize the Product or Service",
-            "description": "Use of specified data categories for the purpose of personalizing the features or services of the application."
+            "fides_key": "improve.system",
+            "name": "System",
+            "parent_key": "improve",
+            "description": "The source system, product, service or application being improved."
         },
         {
-            "fides_key": "marketing_advertising_or_promotion",
-            "name": "Marketing, Advertising or Promotion",
+            "fides_key": "personalize",
+            "name": "Personalize the capability",
+            "description": "Personalize the product, service, application or system."
+        },
+        {
+            "fides_key": "personalize.system",
+            "name": "System",
+            "parent_key": "personalize",
+            "description": "The source system, product, service or application being personalized."
+        },
+        {
+            "fides_key": "advertising",
+            "name": "Advertising, Marketing or Promotion",
             "description": "The promotion of products or services targeted to users based on the the processing of user provided data in the system."
         },
         {
-            "fides_key": "marketing_advertising_or_promotion.first_party",
+            "fides_key": "advertising.first_party",
             "name": "First Party Advertising",
-            "parent_key": "marketing_advertising_or_promotion",
+            "parent_key": "advertising",
             "description": "The promotion of products or services targeting users based on processing of derviced data from prior use of the system."
         },
         {
-            "fides_key": "marketing_advertising_or_promotion.third_party",
+            "fides_key": "advertising.third_party",
             "name": "Third Party Advertising",
-            "parent_key": "marketing_advertising_or_promotion",
+            "parent_key": "advertising",
             "description": "The promotion of products or services targeting users based on processing of specific categories of data acquired from third party sources."
         },
         {
-            "fides_key": "marketing_advertising_or_promotion.first_party.contextual",
+            "fides_key": "advertising.first_party.contextual",
             "name": "First Party Contextual Advertising",
-            "parent_key": "marketing_advertising_or_promotion.first_party",
+            "parent_key": "advertising.first_party",
             "description": "The promotion of products or services targeted to users based on the processing of derived data from the users prior use of the services."
         },
         {
-            "fides_key": "marketing_advertising_or_promotion.first_party.personalized",
+            "fides_key": "advertising.first_party.personalized",
             "name": "First Party Personalized Advertising",
-            "parent_key": "marketing_advertising_or_promotion.first_party",
+            "parent_key": "advertising.first_party",
             "description": "The targeting and changing of promotional content based on processing of specific data categories from the user."
         },
         {
-            "fides_key": "marketing_advertising_or_promotion.third_party.personalized",
+            "fides_key": "advertising.third_party.personalized",
             "name": "Third Party Personalized Advertising",
-            "parent_key": "marketing_advertising_or_promotion.third_party",
+            "parent_key": "advertising.third_party",
             "description": "The targeting and changing of promotional content based on processing of specific categories of user data acquired from third party sources."
         },
         {

--- a/data_uses.yml
+++ b/data_uses.yml
@@ -2,73 +2,96 @@ data_use:
   # Provided Data
   - fides_key: provide_product_or_service
     name: Provide the Product or Service
+    description: Use of specified data categories to provide the proposed service to the user.
 
   - fides_key: provide_product_or_service.support
     name: Support the Product or Service
     parent_key: provide_product_or_service
+    description: Use of specified data categories to operate and protect the system in order to provide the service.
 
   - fides_key: provide_product_or_service.support_optimization
     name: Support Optimization
     parent_key: provide_product_or_service
+    description: Use of specified data categories to ensure appropriate support for the service is being provided.
 
   - fides_key: provide_product_or_service.offer_upgrades
     name: Offers of Product or Service Upgrades
     parent_key: provide_product_or_service
+    description: Offer upgrades or upsales such as increased capacity for the service based on monitoring of service usage.
 
   # Improvement Data
   - fides_key: improve_product_or_service
     name: Improve the Product or Service
+    description: Use specified data categories related to the user or system in order to improve the quality of the service.
 
   # Personalize Data
   - fides_key: personalize_product_or_service
     name: Personalize the Product or Service
+    description: Use of specified data categories for the purpose of personalizing the features or services of the application.
 
   # Marketing, Advertising or Promotion Data
   - fides_key: marketing_advertising_or_promotion
     name: Marketing, Advertising or Promotion
+    description: The promotion of products or services targeted to users based on the the processing of user provided data in the system.
 
   - fides_key: marketing_advertising_or_promotion.first_party
     name: First Party Advertising
     parent_key: marketing_advertising_or_promotion
+    description: The promotion of products or services targeting users based on processing of derviced data from prior use of the system.  
 
   - fides_key: marketing_advertising_or_promotion.third_party
     name: Third Party Advertising
     parent_key: marketing_advertising_or_promotion
+    description: The promotion of products or services targeting users based on processing of specific categories of data acquired from third party sources.
 
   # Marketing, Advertising or Promotion -> First Party Advertising
   - fides_key: marketing_advertising_or_promotion.first_party.contextual
     name: First Party Contextual Advertising
     parent_key: marketing_advertising_or_promotion.first_party
+    description: The promotion of products or services targeted to users based on the processing of derived data from the users prior use of the services.
 
   - fides_key: marketing_advertising_or_promotion.first_party.personalized
     name: First Party Personalized Advertising
     parent_key: marketing_advertising_or_promotion.first_party
+    description: The targeting and changing of promotional content based on processing of specific data categories from the user.
 
   # Marketing, Advertising or Promotion -> Third Party Advertising
   - fides_key: marketing_advertising_or_promotion.third_party.personalized
     name: Third Party Personalized Advertising
     parent_key: marketing_advertising_or_promotion.third_party
+    description: The targeting and changing of promotional content based on processing of specific categories of user data acquired from third party sources.
 
   # Third Party Sharing
   - fides_key: third_party_sharing
     name: Third Party Sharing
+    description: The transfer of specified data categories to third parties outside of the system/application's scope.
 
   - fides_key: third_party_sharing.payment_processing
     name: Sharing for Processing Payments
     parent_key: third_party_sharing
+    description: Sharing of specified data categories with a third party for payment processing.
 
   - fides_key: third_party_sharing.personalized_advertising
     name: Sharing for Personalized Advertising
     parent_key: third_party_sharing
+    description: Sharing of specified data categories for the purpose of marketing/advertising/promotion.
+
+  - fides_key: third_party_sharing.fraud_detection
+    name: Sharing for Fraud Detection
+    parent_key: third_party_sharing
+    description: Sharing of specified data categories with a third party fo fraud prevention/detection.
 
   - fides_key: third_party_sharing.legal_obligation
     name: Sharing for Legal Obligation
     parent_key: third_party_sharing
+    description: Sharing of data for legal obligations, including contracts, applicable laws or regulations.
 
   # Collect
   - fides_key: collect
     name: Collect
+    description: Collecting and storing data in order to use it for another purpose such as data training for ML.
 
   # Train AI System
   - fides_key: train_ai_system
     name: Train AI System
+    description: Training an AI system. Please note when this data use is specified, the method and degree to which a user may be directly identified in the resulting AI system should be appended.

--- a/data_uses.yml
+++ b/data_uses.yml
@@ -1,64 +1,84 @@
 data_use:
   # Provided Data
-  - fides_key: provide_product_or_service
-    name: Provide the Product or Service
-    description: Use of specified data categories to provide the proposed service to the user.
+  - fides_key: provide
+    name: Provide the capability
+    description: Provide, give, or make available the product, service, application or system.
+  
+  - fides_key: provide.system
+    name: System
+    parent_key: provide
+    description: The source system, product, service or application being provided to the user.
 
-  - fides_key: provide_product_or_service.support
-    name: Support the Product or Service
-    parent_key: provide_product_or_service
+  - fides_key: provide.system.operations
+    name: System Operations
+    parent_key: provide.system
     description: Use of specified data categories to operate and protect the system in order to provide the service.
 
-  - fides_key: provide_product_or_service.support_optimization
-    name: Support Optimization
-    parent_key: provide_product_or_service
-    description: Use of specified data categories to ensure appropriate support for the service is being provided.
+  - fides_key: provide.system.operations.support
+    name: Operations Support
+    parent_key: provide.system.operations
+    description: Use of specified data categories to provide support for operation and protection of the system in order to provide the service.
 
-  - fides_key: provide_product_or_service.offer_upgrades
-    name: Offers of Product or Service Upgrades
-    parent_key: provide_product_or_service
+  - fides_key: provide.system.operations.support.optimization
+    name: Support Optimization
+    parent_key: provide.system.operations.support
+    description: Use of specified data categories to optimize and improve support operations in order to provide the service.
+
+  - fides_key: provide.system.upgrades
+    name: Offer Upgrades
+    parent_key: provide.system
     description: Offer upgrades or upsales such as increased capacity for the service based on monitoring of service usage.
 
   # Improvement Data
-  - fides_key: improve_product_or_service
-    name: Improve the Product or Service
-    description: Use specified data categories related to the user or system in order to improve the quality of the service.
+  - fides_key: improve
+    name: Improve the capability
+    description: Improve the product, service, application or system.
+
+  - fides_key: improve.system
+    name: System
+    parent_key: improve
+    description: The source system, product, service or application being improved.
 
   # Personalize Data
-  - fides_key: personalize_product_or_service
-    name: Personalize the Product or Service
-    description: Use of specified data categories for the purpose of personalizing the features or services of the application.
+  - fides_key: personalize
+    name: Personalize the capability
+    description: Personalize the product, service, application or system.
+
+  - fides_key: personalize.system
+    name: System
+    parent_key: personalize
+    description: The source system, product, service or application being personalized.
 
   # Marketing, Advertising or Promotion Data
-  - fides_key: marketing_advertising_or_promotion
-    name: Marketing, Advertising or Promotion
+  - fides_key: advertising
+    name: Advertising, Marketing or Promotion
     description: The promotion of products or services targeted to users based on the the processing of user provided data in the system.
 
-  - fides_key: marketing_advertising_or_promotion.first_party
+  - fides_key: advertising.first_party
     name: First Party Advertising
-    parent_key: marketing_advertising_or_promotion
+    parent_key: advertising
     description: The promotion of products or services targeting users based on processing of derviced data from prior use of the system.  
 
-  - fides_key: marketing_advertising_or_promotion.third_party
+  - fides_key: advertising.third_party
     name: Third Party Advertising
-    parent_key: marketing_advertising_or_promotion
+    parent_key: advertising
     description: The promotion of products or services targeting users based on processing of specific categories of data acquired from third party sources.
 
   # Marketing, Advertising or Promotion -> First Party Advertising
-  - fides_key: marketing_advertising_or_promotion.first_party.contextual
+  - fides_key: advertising.first_party.contextual
     name: First Party Contextual Advertising
-    parent_key: marketing_advertising_or_promotion.first_party
+    parent_key: advertising.first_party
     description: The promotion of products or services targeted to users based on the processing of derived data from the users prior use of the services.
 
-  - fides_key: marketing_advertising_or_promotion.first_party.personalized
+  - fides_key: advertising.first_party.personalized
     name: First Party Personalized Advertising
-    parent_key: marketing_advertising_or_promotion.first_party
+    parent_key: advertising.first_party
     description: The targeting and changing of promotional content based on processing of specific data categories from the user.
 
   # Marketing, Advertising or Promotion -> Third Party Advertising
-  - fides_key: marketing_advertising_or_promotion.third_party.personalized
+  - fides_key: advertising.third_party.personalized
     name: Third Party Personalized Advertising
-    parent_key: marketing_advertising_or_promotion.third_party
+    parent_key: advertising.third_party
     description: The targeting and changing of promotional content based on processing of specific categories of user data acquired from third party sources.
 
   # Third Party Sharing


### PR DESCRIPTION
### Overview
We're migrated from pure snake_case to dot notation to make the taxonomy easier to read and write for every user.

### Changes
Updated the data-use yaml to use dot notation instead of pure snake_case.

### Examples
Previously if you wanted to declare the use of data for optimizing system support it would look like:

`provide_product_or_service.support_optimization`

now, this can be expressed more clearly as:

`provide.system.operations.support`

### Future Improvements/Considerations
There are some areas that could do with additional improvement:
* Redefining marketing and 3rd party data sharing.
* Breaking down other uses of data in third party more concretely
* Exploring other system uses

### Other considerations:
Future state should bind specific data uses to specific data categories such that their use is constrained by the data type or vice-versa. This would lead to fewer risks of accidental misuse of the declarations.



