### PR TITLE
Add a `tags` field to all top-level fides resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,13 @@ The types of changes are:
 * `Fixed` for any bug fixes.
 * `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fideslang/compare/1.0.0...main)
+## [Unreleased](https://github.com/ethyca/fideslang/compare/0.9.0...main)
+
+### Added
+
+* There is now a `tags` field on the `FidesModel` model [#45](https://github.com/ethyca/fideslang/pull/45)
+
+## 0.9.0
 
 ### Added
 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -45,6 +45,7 @@ class FidesModel(BaseModel):
         default="default_organization",
         description="Defines the Organization that this resource belongs to.",
     )
+    tags: List[str]
     name: Optional[str] = name_field
     description: Optional[str] = description_field
 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -45,7 +45,7 @@ class FidesModel(BaseModel):
         default="default_organization",
         description="Defines the Organization that this resource belongs to.",
     )
-    tags: List[str]
+    tags: Optional[List[str]]
     name: Optional[str] = name_field
     description: Optional[str] = description_field
 

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -1,0 +1,32 @@
+import pytest
+
+import fideslang as models
+
+
+@pytest.mark.unit
+class TestSystem:
+    def test_system_valid(self) -> None:
+        system = (
+            models.System(
+                organization_fides_key=1,
+                registry_id=1,
+                meta={"some": "meta stuff"},
+                fides_key="test_system",
+                system_type="SYSTEM",
+                name="Test System",
+                tags=["some", "tags"],
+                description="Test Policy",
+                privacy_declarations=[
+                    models.PrivacyDeclaration(
+                        name="declaration-name",
+                        data_categories=[],
+                        data_use="provide",
+                        data_subjects=[],
+                        data_qualifier="aggregated_data",
+                        dataset_references=[],
+                    )
+                ],
+                system_dependencies=[],
+            ),
+        )
+        assert system


### PR DESCRIPTION
Closes #43

### Code Changes

* [x] add `tags` as a `Optional[List[str]]` field on `FidesModel` 
* [x] add tests

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

This PR adds the `tags` field to all top-level fides resources for eventual resource filtering/grouping
