### PR TITLE
Add DatasetFieldBase model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The types of changes are:
 ### Added
 
 * There is now a `tags` field on the `FidesModel` model [#45](https://github.com/ethyca/fideslang/pull/45)
+* Add DatasetFieldBase model [#49][https://github.com/ethyca/fideslang/pull/49]
 
 ## 0.9.0
 

--- a/src/fideslang/__init__.py
+++ b/src/fideslang/__init__.py
@@ -4,27 +4,29 @@ Exports various fideslang objects for easier use elsewhere.
 
 from typing import Dict, Type, Union
 
+from .default_fixtures import COUNTRY_CODES
+from .default_taxonomy import DEFAULT_TAXONOMY
+
 # Export the Models
 from .models import (
     DataCategory,
     DataQualifier,
-    DataSubject,
-    DataUse,
     Dataset,
     DatasetField,
+    DatasetFieldBase,
+    DataSubject,
+    DataUse,
     Evaluation,
     FidesModel,
     Organization,
     Policy,
     PolicyRule,
+    PrivacyDeclaration,
     PrivacyRule,
     Registry,
-    PrivacyDeclaration,
     System,
     Taxonomy,
 )
-from .default_taxonomy import DEFAULT_TAXONOMY
-from .default_fixtures import COUNTRY_CODES
 
 FidesModelType = Union[Type[FidesModel], Type[Evaluation]]
 model_map: Dict[str, FidesModelType] = {

--- a/src/fideslang/__init__.py
+++ b/src/fideslang/__init__.py
@@ -4,9 +4,6 @@ Exports various fideslang objects for easier use elsewhere.
 
 from typing import Dict, Type, Union
 
-from .default_fixtures import COUNTRY_CODES
-from .default_taxonomy import DEFAULT_TAXONOMY
-
 # Export the Models
 from .models import (
     DataCategory,
@@ -27,6 +24,9 @@ from .models import (
     System,
     Taxonomy,
 )
+
+from .default_fixtures import COUNTRY_CODES
+from .default_taxonomy import DEFAULT_TAXONOMY
 
 FidesModelType = Union[Type[FidesModel], Type[Evaluation]]
 model_map: Dict[str, FidesModelType] = {

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -6,14 +6,14 @@ from __future__ import annotations
 from enum import Enum
 from typing import Dict, List, Optional
 
-from pydantic import root_validator, validator, BaseModel, Field, AnyUrl, HttpUrl
+from pydantic import AnyUrl, BaseModel, Field, HttpUrl, root_validator, validator
 
 from fideslang.validation import (
     FidesKey,
-    sort_list_objects_by_name,
-    no_self_reference,
-    matching_parent_key,
     check_valid_country_code,
+    matching_parent_key,
+    no_self_reference,
+    sort_list_objects_by_name,
 )
 
 # Reusable components
@@ -240,11 +240,26 @@ class DataUse(FidesModel):
 
 
 # Dataset
-class DatasetField(BaseModel):
-    """
-    The DatasetField resource model.
+class DatasetFieldBase(BaseModel):
+    """Base DatasetField Resource model.
 
-    This resource is nested within a DatasetCollection.
+    This model is available for cases where the DatasetField information needs to be
+    customized. In general this will not be the case and you will instead want to use
+    the DatasetField model.
+
+    When this model is used you will need to implement your own recursive field in
+    to adding any new needed fields.
+
+    Example:
+
+    ```py
+    from typing import List, Optional
+    from fideslang import DatasetFieldBase
+
+    class MyDatasetField(DatasetFieldBase):
+        custom: str
+        fields: Optional[List[MyDatasetField]] = []
+    ```
     """
 
     name: str = name_field
@@ -259,6 +274,15 @@ class DatasetField(BaseModel):
     retention: Optional[str] = Field(
         description="An optional string to describe the retention policy for a dataset. This field can also be applied more granularly at either the Collection or field level of a Dataset.",
     )
+
+
+class DatasetField(DatasetFieldBase):
+    """
+    The DatasetField resource model.
+
+    This resource is nested within a DatasetCollection.
+    """
+
     fields: Optional[List[DatasetField]] = Field(
         description="An optional array of objects that describe hierarchical/nested fields (typically found in NoSQL databases).",
     )


### PR DESCRIPTION
Closes <issue>

### Code Changes

* [x] Add a `DatasetFieldBase` modes.
* [x] Change `DatasetField` to inherit from `DatasetFieldBase`.
* [x] Import `DatasetFieldBase` in `__init__.py`.

### Steps to Confirm

* [x] Run the test suite
* [x] In the `fidesops` repository, modify `FidesopsDatasetField` to the following and run the test suite.

```py
class FidesopsDatasetField(FideslangDatasetFieldBase):
    """Extends fideslang DatasetField model with additional Fidesops annotations"""

    fidesops_meta: Optional[FidesopsMeta]
    fields: Optional[List["FidesopsDatasetField"]] = []

    @validator("data_categories")
    def valid_data_categories(
        cls, v: Optional[List[FidesOpsKey]]
    ) -> Optional[List[FidesOpsKey]]:
        """Validate that all annotated data categories exist in the taxonomy"""
        return _valid_data_categories(v)

    @validator("fidesops_meta")
    def valid_meta(cls, meta_values: Optional[FidesopsMeta]) -> Optional[FidesopsMeta]:
        """Validate upfront that the return_all_elements flag can only be specified on array fields"""
        if not meta_values:
            return meta_values

        is_array: bool = bool(
            meta_values.data_type and meta_values.data_type.endswith("[]")
        )
        if not is_array and meta_values.return_all_elements is not None:
            raise ValueError(
                "The 'return_all_elements' attribute can only be specified on array fields."
            )
        return meta_values

    @validator("fields")
    def validate_object_fields(
        cls,
        fields: Optional[List["FidesopsDatasetField"]],
        values: Dict[str, Any],
    ) -> Optional[List["FidesopsDatasetField"]]:
        """Two validation checks for object fields:
        - If there are sub-fields specified, type should be either empty or 'object'
        - Additionally object fields cannot have data_categories.
        """
        declared_data_type = None

        if values.get("fidesops_meta"):
            declared_data_type = values["fidesops_meta"].data_type

        if fields and declared_data_type:
            data_type, _ = parse_data_type_string(declared_data_type)
            if data_type != "object":
                raise InvalidDataTypeValidationError(
                    f"The data type {data_type} is not compatible with specified sub-fields."
                )

        if (fields or declared_data_type == "object") and values.get("data_categories"):
            raise ValueError(
                "Object fields cannot have specified data_categories. Specify category on sub-field instead"
            )

        return fields
```

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

This relates to the issue discussed [here](https://github.com/ethyca/fidesops/pull/454) where `fidesops_meta` can't be added to the `fideslang` `DatasetField`. I tried several different options, and this was the only one that successfully passed the `fidesops` test suite.

Other things tried:

1. Added an`fidesops_meta` field to `DatasetField` with a `FidesopsMeta` type. This didn't work because doing this would require `fideslang` to import `fidesops`.

I tried multiple iterations of the following ideas and they all either failed the `fidesops` test suite, or caused Pydantic to error.

1. Added `fidesops_meta` to `DatasetField` making the field that requires `fidesops` to be imported a generic in order to avoid the import.
1. Added `fidesops_meta` to `DatasetField` making the whole field generic and controlling things from `fidesops`.
1. Added `fidesops_meta` to `DatasetField` making the whole field generic and controlling things from `fidesops`. In addition to this, made the `fields` type in `DatasetField` `Optional[List[Generic[T]]]`.
1. Added `fidesops_meta` to `DatasetField` making the whole field generic and controlling things from `fidesops`. In addition to this, made the `fields` type in `DatasetField` `Optional[List[Generic[T]]]`. Then only added validators to the inheriting class with no extra fields.
1. Made the `fields` type in `DatasetField` `Optional[List[Generic[T]]]`, and only had `fidesops_meta` in the inheriting model.

