### PR TITLE
Base image update from debian buster to bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 python:3.8-slim-buster as base
+FROM --platform=linux/amd64 python:3.8-slim-bullseye as base
 
 # Update pip in the base image since we'll use it everywhere
 RUN pip install -U pip
@@ -15,7 +15,6 @@ RUN : \
     -y --no-install-recommends \
     curl \
     git \
-    ipython \
     make \
     vim \
     g++ \

--- a/mkdocs/Dockerfile
+++ b/mkdocs/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-buster
+FROM python:3.8-slim-bullseye
 
 # Install auxiliary software
 RUN apt-get update


### PR DESCRIPTION
Matching the fideslang and docs base image with the Debian version used in Ethyca's other public repos e.g. https://github.com/ethyca/fides/issues/935

### Code Changes

* [x] `python:3.8-slim-buster` replaced with `python:3.8-slim-bullseye` as base.
* [x] `ipython` removed from `apt-get install` list as it's not a package supported by Debian Bullseye

### Steps to Confirm

* [x] `fideslang` image built locally without errors.
* [x] `docs` image built locally without errors

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

n/a