### PR TITLE
Specify Pydantic < 1.10.0 in requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The types of changes are:
 ### Fixed
 
 * Fixed broken links in docs [#74](https://github.com/ethyca/fideslang/pull/74)
+* Pydantic 1.10.0 was causing issues so specified the pydantic version needs to be less than 1.10.0 [#79](https://github.com/ethyca/fideslang/pull/79)
 
 ## [1.2.0](https://github.com/ethyca/fideslang/compare/1.1.0...1.2.0)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pydantic>=1.8.1,<2.0.0
+pydantic>=1.8.1,<1.10.0
 pyyaml>=5,<6
 versioneer==0.19


### PR DESCRIPTION
Closes <issue>

### Code Changes

* [x] Specified in the `requirements.txt` that Pydantic has to be < 1.10.0

### Steps to Confirm

* [x] Ran tests with pydantic 1.10.0 and they fail. Run again with 1.9.2 and they pass.

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [x] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Pydantic had a release today that is causing the tests to fail. For now I am updating the `requirements.txt` file to require an earlier version and will open a follow-up issue to figure out how to get things working with the new version of pydantic.
