### PR TITLE
Fix default codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Set the fidesctl core team as the default codeowners
 
-* @ethyca/fides-control
+* @ethyca/fidesctl-team
 
 # Set the product/tech writing team as owners for the docs
 


### PR DESCRIPTION
No issue. I've labelled it as a bug, but it's a bug only in how PRs are currently approved, not in fideslang itself.

### Code Changes

* [ ] Updated default codeowners. The old team did not exist.

### Steps to Confirm

n/a - this should only be possible to test from the next PR onwards.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

See above.
