### PR TITLE
Add `DataFlow`s, define `egress` and `ingress` on `System`s and `PrivacyDeclaration`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The types of changes are:
 ### Added
 
 * The `DataFlow` resource model defines a resource with which a `System` resource may communicate [#85](https://github.com/ethyca/fideslang/pull/85)
-* `PrivacyDeclaration`s may define resources to contextualize communications with other resources [#85](https://github.com/ethyca/fideslang/pull/85)
+* `PrivacyDeclaration`s may define `egress` and `ingress`, to contextualize communications with other resources [#85](https://github.com/ethyca/fideslang/pull/85)
 
 ### Developer Experience
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,20 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/1.1.0...main)
 
+### Added
+
+* The `DataFlow` resource model defines a resource with which a `System` resource may communicate [#85](https://github.com/ethyca/fideslang/pull/85)
+* `PrivacyDeclaration`s may define resources to contextualize communications with other resources [#85](https://github.com/ethyca/fideslang/pull/85)
+
+### Developer Experience
+
+* The `DataFlow` resource model is exposed when importing `fideslang` [#85](https://github.com/ethyca/fideslang/pull/85)
+
 ### Fixed
 
 * Fixed broken links in docs [#74](https://github.com/ethyca/fideslang/pull/74)
 * Pydantic 1.10.0 was causing issues so specified the pydantic version needs to be less than 1.10.0 [#79](https://github.com/ethyca/fideslang/pull/79)
+* Resolved a circular import in `default_taxonomy.py` [#85](https://github.com/ethyca/fideslang/pull/85)
 
 ## [1.2.0](https://github.com/ethyca/fideslang/compare/1.1.0...1.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ The types of changes are:
 * The `DataFlow` resource model defines a resource with which a `System` resource may communicate [#85](https://github.com/ethyca/fideslang/pull/85)
 * `PrivacyDeclaration`s may define `egress` and `ingress`, to contextualize communications with other resources [#85](https://github.com/ethyca/fideslang/pull/85)
 
+### Deprecated
+
+* The `dataset_references` field of `PrivacyDeclaration` resources [#85](https://github.com/ethyca/fideslang/pull/85)
+* The `system_dependencies` field of `System` resources [#85](https://github.com/ethyca/fideslang/pull/85)
+
 ### Developer Experience
 
 * The `DataFlow` resource model is exposed when importing `fideslang` [#85](https://github.com/ethyca/fideslang/pull/85)

--- a/demo_resources/demo_system.yml
+++ b/demo_resources/demo_system.yml
@@ -12,6 +12,9 @@ system:
       is_required: True
       progress: Complete
       link: https://example.org/analytics_system_data_protection_impact_assessment
+    ingress:
+      - fides_key: demo_users_dataset
+        type: dataset
     privacy_declarations:
       - name: Analyze customer behaviour for improvements.
         data_categories:
@@ -21,7 +24,7 @@ system:
         data_subjects:
           - customer
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
-        dataset_references:
+        ingress:
           - demo_users_dataset
 
   - fides_key: demo_marketing_system

--- a/mkdocs/docs/resources/system.md
+++ b/mkdocs/docs/resources/system.md
@@ -54,6 +54,14 @@ The array of properties that declare the requirement for and information surroun
 
 Information will be exported as part of the data map or Record of Processing Activites (RoPA)
 
+**egress**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[array]&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+
+The resources to which the System sends data.
+
+**ingress**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[array]&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+
+The resources from which the System receives data.
+
 **privacy_declarations**&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[array]&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 
 The array of declarations describing the types of data in your system. This is a list of the privcy attributes (`data_category`, `data_use`, `data_subject`, and `data_qualifier`) for each of your systems.
@@ -88,6 +96,16 @@ system:
       is_required: True
       progress: Complete
       link: https://example.org/analytics_system_data_protection_impact_assessment
+    egress:
+      - fides_key: another_demo_system
+        type: system
+        data_categories:
+          - user.contact
+    ingress:
+      - fides_key: yet_another_demo_system
+        type: system
+        data_categories:
+          - user.device.cookie_id
     privacy_declarations:
       - name: Analyze customer behaviour for improvements.
         data_categories:
@@ -99,6 +117,10 @@ system:
         data_qualifier: identified_data
         dataset_references:
           - demo_users_dataset
+        egress:
+          - another_demo_system
+        ingress:
+          - yet_another_demo_system
 ```
 
 **Demo manifest file:** `/fides/fidesctl/demo_resources/demo_system.yml`
@@ -121,6 +143,20 @@ system:
     "email": "controller@acmeinc.com",
     "phone": "+1 555 555 5555"
   },
+  "egress": [
+    {
+      "fides_key": "another_demo_system",
+      "type": "system",
+      "data_categories": ["user.contact"]
+    }
+  ],
+  "ingress": [
+    {
+      "fides_key": "yet_another_demo_system",
+      "type": "system",
+      "data_categories": ["user.device.cookie_id"]
+    }
+  ],
   "privacy_declarations": [
     {
       "name": "Analyze customer behaviour for improvements.",

--- a/mkdocs/docs/resources/system.md
+++ b/mkdocs/docs/resources/system.md
@@ -171,7 +171,9 @@ system:
       "data_qualifier": "identified_data",
       "dataset_references": [
         "demo_users_dataset"
-      ]
+      ],
+      "egress": ["another_demo_system"],
+      "ingress": ["yet_another_demo_system"]
     }
   ]
 }

--- a/mkdocs/docs/resources/system.md
+++ b/mkdocs/docs/resources/system.md
@@ -115,8 +115,6 @@ system:
         data_subjects:
           - customer
         data_qualifier: identified_data
-        dataset_references:
-          - demo_users_dataset
         egress:
           - another_demo_system
         ingress:
@@ -169,9 +167,6 @@ system:
         "customer"
       ],
       "data_qualifier": "identified_data",
-      "dataset_references": [
-        "demo_users_dataset"
-      ],
       "egress": ["another_demo_system"],
       "ingress": ["yet_another_demo_system"]
     }

--- a/src/fideslang/__init__.py
+++ b/src/fideslang/__init__.py
@@ -4,9 +4,13 @@ Exports various fideslang objects for easier use elsewhere.
 
 from typing import Dict, Type, Union
 
+from .default_fixtures import COUNTRY_CODES
+from .default_taxonomy import DEFAULT_TAXONOMY
+
 # Export the Models
 from .models import (
     DataCategory,
+    DataFlow,
     DataQualifier,
     Dataset,
     DatasetField,
@@ -24,9 +28,6 @@ from .models import (
     System,
     Taxonomy,
 )
-
-from .default_fixtures import COUNTRY_CODES
-from .default_taxonomy import DEFAULT_TAXONOMY
 
 FidesModelType = Union[Type[FidesModel], Type[Evaluation]]
 model_map: Dict[str, FidesModelType] = {

--- a/src/fideslang/default_taxonomy.py
+++ b/src/fideslang/default_taxonomy.py
@@ -1,6 +1,6 @@
 """This module contains the the default resources that Fideslang ships with."""
 
-from fideslang import (
+from .models import (
     DataCategory,
     DataQualifier,
     DataSubject,

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from enum import Enum
 from typing import Dict, List, Optional
+from warnings import warn
 
 from pydantic import AnyUrl, BaseModel, Field, HttpUrl, root_validator, validator
 
@@ -786,6 +787,21 @@ class System(FidesModel):
                     assert fides_key in [
                         data_flow.fides_key for data_flow in data_flows
                     ], f"PrivacyDeclaration '{value.name}' defines {direction} with '{fides_key}' and is applied to the System '{system}', which does not itself define {direction} with that resource."
+
+        return value
+
+    @validator("system_dependencies")
+    @classmethod
+    def deprecate_system_dependencies(cls, value: List[FidesKey]) -> List[FidesKey]:
+        """
+        Warn that the `system_dependencies` field is deprecated, if set.
+        """
+
+        if value is not None:
+            warn(
+                "The system_dependencies field is deprecated, and will be removed in a future version of fideslang. Use the 'egress' and 'ingress` fields instead.",
+                DeprecationWarning,
+            )
 
         return value
 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -645,6 +645,12 @@ class PrivacyDeclaration(BaseModel):
     dataset_references: Optional[List[FidesKey]] = Field(
         description="Referenced Dataset fides keys used by the system.",
     )
+    egress: Optional[List[FidesKey]] = Field(
+        description="The resources to which data is sent."
+    )
+    ingress: Optional[List[FidesKey]] = Field(
+        description="The resources from which data is received."
+    )
 
 
 class SystemMetadata(BaseModel):

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -716,6 +716,21 @@ class DataFlow(BaseModel):
         description="An array of data categories describing the data in transit.",
     )
 
+    @root_validator()
+    @classmethod
+    def user_special_case(cls, values: Dict) -> Dict:
+        """
+        If either the `fides_key` or the `type` are set to "user",
+        then the other must also be set to "user".
+        """
+
+        if values["fides_key"] == "user" or values["type"] == "user":
+            assert (
+                values["fides_key"] == "user" and values["type"] == "user"
+            ), "The 'user' fides_key is required for, and requires, the type 'user'"
+
+        return values
+
 
 class System(FidesModel):
     """

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -665,6 +665,36 @@ class SystemMetadata(BaseModel):
     )
 
 
+class FlowableResources(str, Enum):
+    """
+    The resource types with which DataFlows can be created.
+    """
+
+    DATASET = "dataset"
+    SYSTEM = "system"
+    USER = "user"
+
+
+class DataFlow(BaseModel):
+    """
+    The DataFlow resource model.
+
+    Describes a resource model with which a given System resource communicates.
+    """
+
+    fides_key: FidesKey = Field(
+        ...,
+        description="Identifies the System or Dataset resource with which the communication occurs. May also be 'user', to represent communication with the user(s) of a System.",
+    )
+    type: FlowableResources = Field(
+        ...,
+        description=f"Specifies the resource model class for which the `fides_key` applies. May be any of {', '.join([v.value for _, v in FlowableResources.__members__.items()])}.",
+    )
+    data_categories: Optional[List[FidesKey]] = Field(
+        description="An array of data categories describing the data in transit.",
+    )
+
+
 class System(FidesModel):
     """
     The System resource model.

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -653,6 +653,21 @@ class PrivacyDeclaration(BaseModel):
         description="The resources from which data is received. Any `fides_key`s included in this list reference `DataFlow` entries in the `ingress` array of any `System` resources to which this `PrivacyDeclaration` is applied."
     )
 
+    @validator("dataset_references")
+    @classmethod
+    def deprecate_dataset_references(cls, value: List[FidesKey]) -> List[FidesKey]:
+        """
+        Warn that the `dataset_references` field is deprecated, if set.
+        """
+
+        if value is not None:
+            warn(
+                "The dataset_references field is deprecated, and will be removed in a future version of fideslang. Use the 'egress' and 'ingress` fields instead.",
+                DeprecationWarning,
+            )
+
+        return value
+
 
 class SystemMetadata(BaseModel):
     """

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -718,6 +718,12 @@ class System(FidesModel):
         default=DataResponsibilityTitle.CONTROLLER,
         description=DataResponsibilityTitle.__doc__,
     )
+    egress: Optional[List[DataFlow]] = Field(
+        description="The resources to which the System sends data."
+    )
+    ingress: Optional[List[DataFlow]] = Field(
+        description="The resources from which the System receives data."
+    )
     privacy_declarations: List[PrivacyDeclaration] = Field(
         description=PrivacyDeclaration.__doc__,
     )

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -646,10 +646,10 @@ class PrivacyDeclaration(BaseModel):
         description="Referenced Dataset fides keys used by the system.",
     )
     egress: Optional[List[FidesKey]] = Field(
-        description="The resources to which data is sent."
+        description="The resources to which data is sent. Any `fides_key`s included in this list reference `DataFlow` entries in the `egress` array of any `System` resources to which this `PrivacyDeclaration` is applied."
     )
     ingress: Optional[List[FidesKey]] = Field(
-        description="The resources from which data is received."
+        description="The resources from which data is received. Any `fides_key`s included in this list reference `DataFlow` entries in the `ingress` array of any `System` resources to which this `PrivacyDeclaration` is applied."
     )
 
 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -694,7 +694,7 @@ class DataFlow(BaseModel):
     )
     type: FlowableResources = Field(
         ...,
-        description=f"Specifies the resource model class for which the `fides_key` applies. May be any of {', '.join([v.value for _, v in FlowableResources.__members__.items()])}.",
+        description="Specifies the resource model class for which the `fides_key` applies. May be any of 'dataset', 'system', or 'user'.",
     )
     data_categories: Optional[List[FidesKey]] = Field(
         description="An array of data categories describing the data in transit.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,7 +121,6 @@ def resources_dict():
                     dataset_references=[],
                 )
             ],
-            system_dependencies=[],
         ),
     }
     yield resources_dict

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,7 +118,6 @@ def resources_dict():
                     data_use="provide",
                     data_subjects=[],
                     data_qualifier="aggregated_data",
-                    dataset_references=[],
                 )
             ],
         ),

--- a/tests/data/failing_dataset_collection_taxonomy.yml
+++ b/tests/data/failing_dataset_collection_taxonomy.yml
@@ -30,7 +30,6 @@ system:
           - customer
         dataset_references:
           - test_db_dataset_failing_dataset
-    system_dependencies: []
 
 policy:
   - fides_key: primary_privacy_policy

--- a/tests/data/failing_dataset_collection_taxonomy.yml
+++ b/tests/data/failing_dataset_collection_taxonomy.yml
@@ -20,6 +20,9 @@ system:
     name: Customer Data Sharing System
     description: Share data about our users with third-parties for advertising
     system_type: Service
+    ingress:
+      - fides_key: test_db_dataset_failing_dataset
+        type: dataset
     privacy_declarations:
       - name: Share Political Opinions
         data_categories:
@@ -28,7 +31,7 @@ system:
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
         data_subjects:
           - customer
-        dataset_references:
+        ingress:
           - test_db_dataset_failing_dataset
 
 policy:

--- a/tests/data/failing_dataset_field_taxonomy.yml
+++ b/tests/data/failing_dataset_field_taxonomy.yml
@@ -31,7 +31,6 @@ system:
           - customer
         dataset_references:
           - test_db_dataset_failing_dataset
-    system_dependencies: []
 
 policy:
   - fides_key: primary_privacy_policy

--- a/tests/data/failing_dataset_field_taxonomy.yml
+++ b/tests/data/failing_dataset_field_taxonomy.yml
@@ -21,6 +21,9 @@ system:
     name: Customer Data Sharing System
     description: Share data about our users with third-parties for advertising
     system_type: Service
+    ingress:
+      - fides_key: test_db_dataset_failing_dataset
+        type: dataset
     privacy_declarations:
       - name: Share Political Opinions
         data_categories:
@@ -29,7 +32,7 @@ system:
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
         data_subjects:
           - customer
-        dataset_references:
+        ingress:
           - test_db_dataset_failing_dataset
 
 policy:

--- a/tests/data/failing_dataset_taxonomy.yml
+++ b/tests/data/failing_dataset_taxonomy.yml
@@ -30,7 +30,6 @@ system:
           - customer
         dataset_references:
           - test_db_dataset_failing_dataset
-    system_dependencies: []
 
 policy:
   - fides_key: primary_privacy_policy

--- a/tests/data/failing_dataset_taxonomy.yml
+++ b/tests/data/failing_dataset_taxonomy.yml
@@ -20,6 +20,9 @@ system:
     name: Customer Data Sharing System
     description: Share data about our users with third-parties for advertising
     system_type: Service
+    ingress:
+      - fides_key: test_db_dataset_failing_dataset
+        type: dataset
     privacy_declarations:
       - name: Share Political Opinions
         data_categories:
@@ -28,7 +31,7 @@ system:
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
         data_subjects:
           - customer
-        dataset_references:
+        ingress:
           - test_db_dataset_failing_dataset
 
 policy:

--- a/tests/data/failing_declaration_taxonomy.yml
+++ b/tests/data/failing_declaration_taxonomy.yml
@@ -11,7 +11,6 @@ system:
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
         data_subjects:
           - customer
-    system_dependencies: []
 
 policy:
   - fides_key: primary_privacy_policy

--- a/tests/data/failing_nested_dataset.yml
+++ b/tests/data/failing_nested_dataset.yml
@@ -24,6 +24,9 @@ system:
     name: Client Usage Analytics
     description: Use aggregated and anonymous data to measure usage
     system_type: Service
+    ingress:
+      - fides_key: test_failing_nested_dataset_field
+        type: dataset
     privacy_declarations:
       - name: Mesaure usage of users
         data_categories:
@@ -32,7 +35,7 @@ system:
         data_subjects:
           - customer
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
-        dataset_references:
+        ingress:
           - test_failing_nested_dataset_field
 
 policy:

--- a/tests/data/passing_declaration_taxonomy.yml
+++ b/tests/data/passing_declaration_taxonomy.yml
@@ -11,7 +11,6 @@ system:
         data_qualifier: aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified
         data_subjects:
           - customer
-    system_dependencies: []
 
 policy:
   - fides_key: primary_privacy_policy

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -44,6 +44,29 @@ class TestSystem:
             tags=["some", "tags"],
         )
 
+    def test_system_valid_no_egress_or_ingress(self) -> None:
+        assert System(
+            description="Test Policy",
+            fides_key="test_system",
+            meta={"some": "meta stuff"},
+            name="Test System",
+            organization_fides_key=1,
+            privacy_declarations=[
+                PrivacyDeclaration(
+                    data_categories=[],
+                    data_qualifier="aggregated_data",
+                    data_subjects=[],
+                    data_use="provide",
+                    dataset_references=[],
+                    name="declaration-name",
+                )
+            ],
+            registry_id=1,
+            system_dependencies=[],
+            system_type="SYSTEM",
+            tags=["some", "tags"],
+        )
+
     def test_system_no_egress(self) -> None:
         with pytest.raises(ValueError):
             assert System(

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -1,6 +1,6 @@
 import pytest
 
-from fideslang import PrivacyDeclaration, System
+from fideslang import DataFlow, PrivacyDeclaration, System
 
 
 @pytest.mark.unit
@@ -8,7 +8,21 @@ class TestSystem:
     def test_system_valid(self) -> None:
         assert System(
             description="Test Policy",
+            egress=[
+                DataFlow(
+                    fides_key="test_system_2",
+                    type="system",
+                    data_categories=[],
+                )
+            ],
             fides_key="test_system",
+            ingress=[
+                DataFlow(
+                    fides_key="test_system_3",
+                    type="system",
+                    data_categories=[],
+                )
+            ],
             meta={"some": "meta stuff"},
             name="Test System",
             organization_fides_key=1,
@@ -19,6 +33,8 @@ class TestSystem:
                     data_subjects=[],
                     data_use="provide",
                     dataset_references=[],
+                    egress=["test_system_2"],
+                    ingress=["test_system_3"],
                     name="declaration-name",
                 )
             ],

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -1,9 +1,27 @@
-import pytest
+from pytest import deprecated_call, mark, raises
 
 from fideslang import DataFlow, PrivacyDeclaration, System
 
+pytestmark = mark.unit
 
-@pytest.mark.unit
+
+class TestDataFlow:
+    def test_dataflow_valid(self) -> None:
+        assert DataFlow(
+            fides_key="test_system_1",
+            type="system",
+            data_categories=[],
+        )
+
+    def test_dataflow_user_fides_key_no_user_type(self) -> None:
+        with raises(ValueError):
+            assert DataFlow(fides_key="user", type="system")
+
+    def test_dataflow_user_type_no_user_fides_key(self) -> None:
+        with raises(ValueError):
+            assert DataFlow(fides_key="test_system_1", type="user")
+
+
 class TestPrivacyDeclaration:
     def test_privacydeclaration_valid(self) -> None:
         assert PrivacyDeclaration(
@@ -17,7 +35,7 @@ class TestPrivacyDeclaration:
         )
 
     def test_dataset_references_deprecation(self) -> None:
-        with pytest.deprecated_call(match="dataset_references"):
+        with deprecated_call(match="dataset_references"):
             assert PrivacyDeclaration(
                 data_categories=[],
                 data_qualifier="aggregated_data",
@@ -30,7 +48,6 @@ class TestPrivacyDeclaration:
             )
 
 
-@pytest.mark.unit
 class TestSystem:
     def test_system_valid(self) -> None:
         assert System(
@@ -70,7 +87,7 @@ class TestSystem:
         )
 
     def test_system_dependencies_deprecation(self) -> None:
-        with pytest.deprecated_call(match="system_dependencies"):
+        with deprecated_call(match="system_dependencies"):
             assert System(
                 description="Test Policy",
                 egress=[
@@ -130,7 +147,7 @@ class TestSystem:
         )
 
     def test_system_no_egress(self) -> None:
-        with pytest.raises(ValueError):
+        with raises(ValueError):
             assert System(
                 description="Test Policy",
                 fides_key="test_system",
@@ -161,7 +178,7 @@ class TestSystem:
             )
 
     def test_system_no_ingress(self) -> None:
-        with pytest.raises(ValueError):
+        with raises(ValueError):
             assert System(
                 description="Test Policy",
                 egress=[

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -1,32 +1,29 @@
 import pytest
 
-import fideslang as models
+from fideslang import PrivacyDeclaration, System
 
 
 @pytest.mark.unit
 class TestSystem:
     def test_system_valid(self) -> None:
-        system = (
-            models.System(
-                organization_fides_key=1,
-                registry_id=1,
-                meta={"some": "meta stuff"},
-                fides_key="test_system",
-                system_type="SYSTEM",
-                name="Test System",
-                tags=["some", "tags"],
-                description="Test Policy",
-                privacy_declarations=[
-                    models.PrivacyDeclaration(
-                        name="declaration-name",
-                        data_categories=[],
-                        data_use="provide",
-                        data_subjects=[],
-                        data_qualifier="aggregated_data",
-                        dataset_references=[],
-                    )
-                ],
-                system_dependencies=[],
-            ),
+        assert System(
+            description="Test Policy",
+            fides_key="test_system",
+            meta={"some": "meta stuff"},
+            name="Test System",
+            organization_fides_key=1,
+            privacy_declarations=[
+                PrivacyDeclaration(
+                    data_categories=[],
+                    data_qualifier="aggregated_data",
+                    data_subjects=[],
+                    data_use="provide",
+                    dataset_references=[],
+                    name="declaration-name",
+                )
+            ],
+            registry_id=1,
+            system_dependencies=[],
+            system_type="SYSTEM",
+            tags=["some", "tags"],
         )
-        assert system

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -207,3 +207,32 @@ class TestSystem:
                 system_type="SYSTEM",
                 tags=["some", "tags"],
             )
+
+    def test_system_user_ingress_valid(self) -> None:
+        assert System(
+            description="Test Policy",
+            fides_key="test_system",
+            ingress=[
+                DataFlow(
+                    fides_key="user",
+                    type="user",
+                    data_categories=[],
+                )
+            ],
+            meta={"some": "meta stuff"},
+            name="Test System",
+            organization_fides_key=1,
+            privacy_declarations=[
+                PrivacyDeclaration(
+                    data_categories=[],
+                    data_qualifier="aggregated_data",
+                    data_subjects=[],
+                    data_use="provide",
+                    ingress=["user"],
+                    name="declaration-name",
+                )
+            ],
+            registry_id=1,
+            system_type="SYSTEM",
+            tags=["some", "tags"],
+        )

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -39,10 +39,49 @@ class TestSystem:
                 )
             ],
             registry_id=1,
-            system_dependencies=[],
             system_type="SYSTEM",
             tags=["some", "tags"],
         )
+
+    def test_system_dependencies_deprecation(self) -> None:
+        with pytest.deprecated_call(match="system_dependencies"):
+            assert System(
+                description="Test Policy",
+                egress=[
+                    DataFlow(
+                        fides_key="test_system_2",
+                        type="system",
+                        data_categories=[],
+                    )
+                ],
+                fides_key="test_system",
+                ingress=[
+                    DataFlow(
+                        fides_key="test_system_3",
+                        type="system",
+                        data_categories=[],
+                    )
+                ],
+                meta={"some": "meta stuff"},
+                name="Test System",
+                organization_fides_key=1,
+                privacy_declarations=[
+                    PrivacyDeclaration(
+                        data_categories=[],
+                        data_qualifier="aggregated_data",
+                        data_subjects=[],
+                        data_use="provide",
+                        dataset_references=[],
+                        egress=["test_system_2"],
+                        ingress=["test_system_3"],
+                        name="declaration-name",
+                    )
+                ],
+                registry_id=1,
+                system_dependencies=[],
+                system_type="SYSTEM",
+                tags=["some", "tags"],
+            )
 
     def test_system_valid_no_egress_or_ingress(self) -> None:
         assert System(
@@ -62,7 +101,6 @@ class TestSystem:
                 )
             ],
             registry_id=1,
-            system_dependencies=[],
             system_type="SYSTEM",
             tags=["some", "tags"],
         )
@@ -95,7 +133,6 @@ class TestSystem:
                     )
                 ],
                 registry_id=1,
-                system_dependencies=[],
                 system_type="SYSTEM",
                 tags=["some", "tags"],
             )
@@ -128,7 +165,6 @@ class TestSystem:
                     )
                 ],
                 registry_id=1,
-                system_dependencies=[],
                 system_type="SYSTEM",
                 tags=["some", "tags"],
             )

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -43,3 +43,69 @@ class TestSystem:
             system_type="SYSTEM",
             tags=["some", "tags"],
         )
+
+    def test_system_no_egress(self) -> None:
+        with pytest.raises(ValueError):
+            assert System(
+                description="Test Policy",
+                fides_key="test_system",
+                ingress=[
+                    DataFlow(
+                        fides_key="test_system_3",
+                        type="system",
+                        data_categories=[],
+                    )
+                ],
+                meta={"some": "meta stuff"},
+                name="Test System",
+                organization_fides_key=1,
+                privacy_declarations=[
+                    PrivacyDeclaration(
+                        data_categories=[],
+                        data_qualifier="aggregated_data",
+                        data_subjects=[],
+                        data_use="provide",
+                        dataset_references=[],
+                        egress=["test_system_2"],
+                        ingress=["test_system_3"],
+                        name="declaration-name",
+                    )
+                ],
+                registry_id=1,
+                system_dependencies=[],
+                system_type="SYSTEM",
+                tags=["some", "tags"],
+            )
+
+    def test_system_no_ingress(self) -> None:
+        with pytest.raises(ValueError):
+            assert System(
+                description="Test Policy",
+                egress=[
+                    DataFlow(
+                        fides_key="test_system_2",
+                        type="system",
+                        data_categories=[],
+                    )
+                ],
+                fides_key="test_system",
+                meta={"some": "meta stuff"},
+                name="Test System",
+                organization_fides_key=1,
+                privacy_declarations=[
+                    PrivacyDeclaration(
+                        data_categories=[],
+                        data_qualifier="aggregated_data",
+                        data_subjects=[],
+                        data_use="provide",
+                        dataset_references=[],
+                        egress=["test_system_2"],
+                        ingress=["test_system_3"],
+                        name="declaration-name",
+                    )
+                ],
+                registry_id=1,
+                system_dependencies=[],
+                system_type="SYSTEM",
+                tags=["some", "tags"],
+            )

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -4,6 +4,33 @@ from fideslang import DataFlow, PrivacyDeclaration, System
 
 
 @pytest.mark.unit
+class TestPrivacyDeclaration:
+    def test_privacydeclaration_valid(self) -> None:
+        assert PrivacyDeclaration(
+            data_categories=[],
+            data_qualifier="aggregated_data",
+            data_subjects=[],
+            data_use="provide",
+            egress=[],
+            ingress=[],
+            name="declaration-name",
+        )
+
+    def test_dataset_references_deprecation(self) -> None:
+        with pytest.deprecated_call(match="dataset_references"):
+            assert PrivacyDeclaration(
+                data_categories=[],
+                data_qualifier="aggregated_data",
+                data_subjects=[],
+                data_use="provide",
+                dataset_references=[],
+                egress=["test_system_2"],
+                ingress=["test_system_3"],
+                name="declaration-name",
+            )
+
+
+@pytest.mark.unit
 class TestSystem:
     def test_system_valid(self) -> None:
         assert System(
@@ -32,7 +59,6 @@ class TestSystem:
                     data_qualifier="aggregated_data",
                     data_subjects=[],
                     data_use="provide",
-                    dataset_references=[],
                     egress=["test_system_2"],
                     ingress=["test_system_3"],
                     name="declaration-name",
@@ -71,7 +97,6 @@ class TestSystem:
                         data_qualifier="aggregated_data",
                         data_subjects=[],
                         data_use="provide",
-                        dataset_references=[],
                         egress=["test_system_2"],
                         ingress=["test_system_3"],
                         name="declaration-name",
@@ -96,7 +121,6 @@ class TestSystem:
                     data_qualifier="aggregated_data",
                     data_subjects=[],
                     data_use="provide",
-                    dataset_references=[],
                     name="declaration-name",
                 )
             ],
@@ -126,7 +150,6 @@ class TestSystem:
                         data_qualifier="aggregated_data",
                         data_subjects=[],
                         data_use="provide",
-                        dataset_references=[],
                         egress=["test_system_2"],
                         ingress=["test_system_3"],
                         name="declaration-name",
@@ -158,7 +181,6 @@ class TestSystem:
                         data_qualifier="aggregated_data",
                         data_subjects=[],
                         data_use="provide",
-                        dataset_references=[],
                         egress=["test_system_2"],
                         ingress=["test_system_3"],
                         name="declaration-name",


### PR DESCRIPTION
Closes #83

### Code Changes

* [x] Define `egress` and `ingress` `FidesKey`s on `PrivacyDeclaration`s
* [x] Define the `DataFlow` resource model, and the companion `FlowableResources` `Enum`
* [x] Define `egress` and `ingress` `DataFlow`s on `System` resources
* [x] Validate that any `PrivacyDeclaration`s applied to a given `System` only reference `egress` and `ingress` `FidesKey`s that are also defined in that System's `egress` and `ingress` `DataFlow`s, respectively
* [x] Validate that any `DataFlow`s which set their `fides_key` and/or `type` field(s) to "user" also set their other field to "user"
* [x] Deprecate `PrivacyDeclaration.dataset_references` and `System.system_dependencies`
* [x] Fix some broken stuff

### Steps to Confirm

* [ ] Run the tests (they should pass)

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Issue Requirements are Met
* [ ] ~Relevant Follow-Up Issues Created~
* [x] Update `CHANGELOG.md`