### PR TITLE
Assert `DataFlow.type` as a `str`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,13 @@ The types of changes are:
 * `Fixed` for any bug fixes.
 * `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fideslang/compare/1.1.0...main)
+## [Unreleased](https://github.com/ethyca/fideslang/compare/1.3.0...main)
+
+### Fixed
+
+* `DataFlow` resource models included in `System` resource models are now exported to valid YAML [#89](https://github.com/ethyca/fideslang/pull/89)
+
+## [1.3.0](https://github.com/ethyca/fideslang/compare/1.2.0...1.3.0)
 
 ### Added
 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -708,15 +708,15 @@ class DataFlow(BaseModel):
         ...,
         description="Identifies the System or Dataset resource with which the communication occurs. May also be 'user', to represent communication with the user(s) of a System.",
     )
-    type: FlowableResources = Field(
+    type: str = Field(
         ...,
-        description="Specifies the resource model class for which the `fides_key` applies. May be any of 'dataset', 'system', or 'user'.",
+        description=f"Specifies the resource model class for which the `fides_key` applies. May be any of {', '.join([member.value for member in FlowableResources])}.",
     )
     data_categories: Optional[List[FidesKey]] = Field(
         description="An array of data categories describing the data in transit.",
     )
 
-    @root_validator()
+    @root_validator(skip_on_failure=True)
     @classmethod
     def user_special_case(cls, values: Dict) -> Dict:
         """
@@ -730,6 +730,18 @@ class DataFlow(BaseModel):
             ), "The 'user' fides_key is required for, and requires, the type 'user'"
 
         return values
+
+    @validator("type")
+    @classmethod
+    def verify_type_is_flowable(cls, value: str) -> str:
+        """
+        Assert that the value of the `type` field is a member
+        of the `FlowableResources` Enum.
+        """
+
+        flowables = [member.value for member in FlowableResources]
+        assert value in flowables, f"'type' must be one of {', '.join(flowables)}"
+        return value
 
 
 class System(FidesModel):

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -21,6 +21,10 @@ class TestDataFlow:
         with raises(ValueError):
             assert DataFlow(fides_key="test_system_1", type="user")
 
+    def test_dataflow_invalid_type(self) -> None:
+        with raises(ValueError):
+            assert DataFlow(fides_key="test_system_1", type="invalid")
+
 
 class TestPrivacyDeclaration:
     def test_privacydeclaration_valid(self) -> None:


### PR DESCRIPTION
Closes #88

### Code Changes

* [x] `DataFlow.type` --> `str`
* [x] Validate that `DataFlow.type` values are included in the `FlowableResources` `Enum`
* [x] Add a test for the new validator

### Steps to Confirm

* [ ] Run the tests (they should pass)
* [ ] Create a `System` resource with `DataFlow`s, and export it as YAML

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`

### Description Of Changes

Resolves an issue where `System` resources that include lists of `DataFlow`s were exported to invalid YAML.