### PR TITLE
DOX-180 update user contact taxonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/1.3.1...main)
 
+## Docs
+* Update the visual taxonomy to reflect appropriate `user.contact.address` nesting [#92](https://github.com/ethyca/fideslang/pull/92)
+
 ## [1.3.1](https://github.com/ethyca/fideslang/compare/1.3.0...1.3.1)
 
 ### Fixed

--- a/mkdocs/docs/csv/data_categories.csv
+++ b/mkdocs/docs/csv/data_categories.csv
@@ -20,13 +20,14 @@ user.device.cookie_id,Cookie ID,user.device,Cookie unique identification number.
 user.device.device_id,Device ID,user.device,Device unique identification number.
 user.device.ip_address,IP Address,user.device,Unique identifier related to device connection.
 user.contact,Contact Data,user,User contact data for purposes other than account management.
-user.contact.city,User Contact City,user.contact,"User's city level address data."
-user.contact.country,User Contact Country,user.contact,"User's country level address data."
 user.contact.email,User Contact Email,user.contact,"User's email address."
 user.contact.phone_number,User Contact Phone Number,user.contact,"User's phone number."
-user.contact.postal_code,User Contact Postal Code,user.contact,"User's postal code."
-user.contact.state,User Contact State,user.contact,"User's state level address data."
-user.contact.street,User Contact Street,user.contact,"User's street level address data."
+user.contact.address,Address Data,user.contact,User contact data related to an address.
+user.contact.address.city,User Contact City,user.contact.address,"User's city level address data."
+user.contact.address.country,User Contact Country,user.contact.address,"User's country level address data."
+user.contact.address.postal_code,User Contact Postal Code,user.contact.address,"User's postal code."
+user.contact.address.state,User Contact State,user.contact.address,"User's state level address data."
+user.contact.address.street,User Contact Street,user.contact.address,"User's street level address data."
 user.credentials,Credentials,user,User authentication data.
 user.credentials.biometric_credentials,Biometric Credentials,user.credentials,Credentials for system authentication.
 user.credentials.password,Password,user.credentials,Password for system authentication.

--- a/mkdocs/docs/taxonomy/data_categories.md
+++ b/mkdocs/docs/taxonomy/data_categories.md
@@ -68,10 +68,10 @@ Below is a reference for all subcategories of `system` and `user` to assist with
 | `browsing_history`                | `user`                                    |Content browsing history of a user.                                                            |
 | `contact`                         | `user`                                    |User contact data.                                                                             |
 | `address`                         | `user.contact`                            |User contact data related to an address.                                                       |
+| `email`                           | `user.contact`                    |User's email address.                                                                          |
+| `phone_number`                    | `user.contact`                    |User's phone number.                                                                           |
 | `city`                            | `user.contact.address`                    |User's city level address data.                                                                |
 | `country`                         | `user.contact.address`                    |User's country level address data.                                                             |
-| `email`                           | `user.contact.address`                    |User's email address.                                                                          |
-| `phone_number`                    | `user.contact.address`                    |User's phone number.                                                                           |
 | `postal_code`                     | `user.contact.address`                    |User's postal code.                                                                            |
 | `state`                           | `user.contact.address`                    |User's state level address data.                                                               |
 | `street`                          | `user.contact.address`                    |User's street level address data.                                                              |


### PR DESCRIPTION
Closes <issue>

### Code Changes

* Update the `phone_number` and `address` nesting in the docs and visual taxonomy to match.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [x] Documentation Updated
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md
