### PR TITLE
Make `PrivacyDeclation.name` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,17 @@ The types of changes are:
 * `Fixed` for any bug fixes.
 * `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fideslang/compare/1.3.1...main)
+## [Unreleased](https://github.com/ethyca/fideslang/compare/1.3.2...main)
 
 ### Changed
+* Make `PrivacyDeclation.name` optional [#97](https://github.com/ethyca/fideslang/pull/97)
 
+## [1.3.2](https://github.com/ethyca/fideslang/compare/1.3.1...1.3.2)
+
+### Changed
+* Update css to brand colors, edit footer [#87](https://github.com/ethyca/fideslang/pull/87)
 * Moved over DSR concepts into Fideslang. Expanded allowable characters for FideKey and added additional Dataset validation. [#95](https://github.com/ethyca/fideslang/pull/95)
-
+* Docs css and link updates [#93](https://github.com/ethyca/fideslang/pull/93)
 
 ## [1.3.1](https://github.com/ethyca/fideslang/compare/1.3.0...1.3.1)
 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -783,7 +783,7 @@ class PrivacyDeclaration(BaseModel):
     to the privacy data types.
     """
 
-    name: str = Field(
+    name: Optional[str] = Field(
         description="The name of the privacy declaration on the system.",
     )
     data_categories: List[FidesKey] = Field(


### PR DESCRIPTION
### Code Changes

* [ ] Make `PrivacyDeclation.name` optional

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

This change is support the updates required for https://github.com/ethyca/fidesplus/issues/514. Making `PrivacyDeclation.name` optional allows fides to reuse the preexisting privacy declaration column.
