### PR TITLE
set privacy declarations to use orm_mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ The types of changes are:
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/1.3.2...main)
 
 ### Changed
+* Make `PrivacyDeclaration` use pydantic `orm_mode` [#101](https://github.com/ethyca/fideslang/pull/101)
+
+## [1.3.3](https://github.com/ethyca/fideslang/compare/1.3.2...1.3.3)
+
+### Changed
 * Make `PrivacyDeclation.name` optional [#97](https://github.com/ethyca/fideslang/pull/97)
 
 ## [1.3.2](https://github.com/ethyca/fideslang/compare/1.3.1...1.3.2)

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -824,6 +824,11 @@ class PrivacyDeclaration(BaseModel):
 
         return value
 
+    class Config:
+        """Config for the Privacy Declaration"""
+
+        orm_mode = True
+
 
 class SystemMetadata(BaseModel):
     """


### PR DESCRIPTION
Closes #100 

### Code Changes

* set `orm_mode = True` on the `PrivacyDeclaration` model

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

Needed for https://github.com/ethyca/fides/issues/3036.

I _may_ need some additional changes to `fideslang` as part of https://github.com/ethyca/fides/issues/3036, though I think this is all that's needed currently. ~@ThomasLaPiana or anyone else - do we have any quick way to develop `fides` against new `fideslang` code without actually pushing through a release?~ update - i was able to develop/test against these changes by locally updating the `requirements.txt` in `fides` to point to this specific git commit. things generally looked good, i don't foresee any additional changes needed on the `fideslang` side at the moment - but there's still a _slight_ chance that could change going forward!
