### PR TITLE
add `id` field to `PrivacyDeclaration` model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ The types of changes are:
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/1.3.2...main)
 
 ### Changed
+* Include an optional `id` field on `PrivacyDeclaration` model [#103](https://github.com/ethyca/fideslang/pull/103)
+
+## [1.3.4](https://github.com/ethyca/fideslang/compare/1.3.3...1.3.4)
+
+### Changed
 * Make `PrivacyDeclaration` use pydantic `orm_mode` [#101](https://github.com/ethyca/fideslang/pull/101)
 
 ## [1.3.3](https://github.com/ethyca/fideslang/compare/1.3.2...1.3.3)

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -783,6 +783,9 @@ class PrivacyDeclaration(BaseModel):
     to the privacy data types.
     """
 
+    id: Optional[str] = Field(
+        description="The database-assigned ID of the privacy declaration on the system. This is meant to be a read-only field."
+    )
     name: Optional[str] = Field(
         description="The name of the privacy declaration on the system.",
     )

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -1,6 +1,6 @@
 from pytest import deprecated_call, mark, raises
 
-from fideslang import DataFlow, PrivacyDeclaration, System, Dataset
+from fideslang import DataFlow, Dataset, PrivacyDeclaration, System
 from fideslang.models import DatasetCollection, DatasetField
 
 pytestmark = mark.unit
@@ -30,6 +30,18 @@ class TestDataFlow:
 class TestPrivacyDeclaration:
     def test_privacydeclaration_valid(self) -> None:
         assert PrivacyDeclaration(
+            data_categories=[],
+            data_qualifier="aggregated_data",
+            data_subjects=[],
+            data_use="provide",
+            egress=[],
+            ingress=[],
+            name="declaration-name",
+        )
+
+    def test_privacydeclaration_valid_with_id(self) -> None:
+        assert PrivacyDeclaration(
+            id="pri_12345",
             data_categories=[],
             data_qualifier="aggregated_data",
             data_subjects=[],


### PR DESCRIPTION
Closes #102 

### Code Changes

* add `id` field to `PrivacyDeclaration` model

### Steps to Confirm

* we'll need to integrate this into `fides` to be able to confirm it adds the API response data we are looking for
    * i confirmed this works as expected by pinning `fides` to this `fideslang` commit in the `requirements.txt`. the API response to getting a system with privacy declarations looked like this (note the `id` fields):
 ```
{
  "fides_key": "test_system_1",
  "organization_fides_key": "default_organization",
  "tags": [],
  "name": "test system 1",
  "description": "",
  "registry_id": null,
  "meta": null,
  "fidesctl_meta": null,
  "system_type": "",
  "data_responsibility_title": "Controller",
  "egress": null,
  "ingress": null,
  "privacy_declarations": [
    {
      "id": "pri_eb5ad4c6-164a-47c1-a803-a84078b24dde",
      "name": "test",
      "data_categories": [
        "user"
      ],
      "data_use": "advertising",
      "data_qualifier": "aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified",
      "data_subjects": [
        "commuter"
      ],
      "dataset_references": [],
      "egress": null,
      "ingress": null
    },
    {
      "id": "pri_ce89b310-3015-4373-bc94-2180b63d270e",
      "name": "test 2",
      "data_categories": [
        "user.browsing_history"
      ],
      "data_use": "advertising",
      "data_qualifier": "aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified",
      "data_subjects": [
        "next_of_kin"
      ],
      "dataset_references": [],
      "egress": null,
      "ingress": null
    }
  ],
  "system_dependencies": [],
  "joint_controller": null,
  "third_country_transfers": [],
  "administrating_department": "Not defined",
  "data_protection_impact_assessment": {
    "is_required": false,
    "progress": null,
    "link": null
  }
}
```

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

See issue for more context around the change. Essentially, I think we need to return the `PrivacyDeclaration.id` property to be able to link `CustomField`s to `PrivacyDeclaration`s