### PR TITLE
import `Literal` from `typing_extensions` to work around pydantic bug

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ ipython
 mypy==0.910
 packaging==20.9
 pre-commit==2.9.3
-pylint==2.6.0
+pylint==2.10.0
 pytest==6.2.2
 pytest-cov==2.11.1
 requests-mock==1.8.0

--- a/src/fideslang/manifests.py
+++ b/src/fideslang/manifests.py
@@ -17,7 +17,7 @@ def write_manifest(
     else:
         manifest = {resource_type: manifest}
 
-    with open(file_name, "w") as manifest_file:
+    with open(file_name, "w", encoding="utf-8") as manifest_file:
         yaml.dump(manifest, manifest_file, sort_keys=False, indent=2)
 
 
@@ -25,7 +25,7 @@ def load_yaml_into_dict(file_path: str) -> Dict:
     """
     This loads yaml files into a dictionary to be used in API calls.
     """
-    with open(file_path, "r") as yaml_file:
+    with open(file_path, "r", encoding="utf-8") as yaml_file:
         loaded = yaml.safe_load(yaml_file)
         if isinstance(loaded, dict):
             return loaded

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -6,7 +6,7 @@ Contains all of the Fides resources modeled as Pydantic models.
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 from warnings import warn
 
 from pydantic import (
@@ -19,6 +19,9 @@ from pydantic import (
     root_validator,
     validator,
 )
+
+# import `Literal` from typing_extensions to work around https://github.com/pydantic/pydantic/issues/5821
+from typing_extensions import Literal
 
 from fideslang.validation import (
     FidesKey,


### PR DESCRIPTION
Closes #108.

Caused by https://github.com/pydantic/pydantic/issues/5821.

### Code Changes

* import `Literal` from `typing_extensions` to work around the pydantic bug introduced with typing_extensions version `4.6.0`

### Steps to Confirm

* CI passes

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

I decided on this workaround here in `fideslang` (see https://github.com/pydantic/pydantic/issues/5821#issuecomment-1559196859 for a list of potential workaround) for a couple of reasons:
- we only have a single use of `Literal`
- in `fideslang`, pinning the `typing_extensions` package to `4.5.0` (which is the workaround i'd decided on in `fides` https://github.com/ethyca/fides/pull/3357) could come with more, and less visible, consequences for "downstream" users of the package, if e.g. other applications need to have `typing_extensions` on a _higher_ version.
    - so instead of potentially getting in their way, a simple code patch here means we shouldn't have any impact on others using this package
