### PR TITLE
make `meta` attribute on `System` and `Dataset` model more permissive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,27 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fideslang/compare/1.3.2...main)
+## [Unreleased](https://github.com/ethyca/fideslang/compare/1.3.4...main)
+
+### Changed
+
+- Make `meta` property of `System` and `Dataset` models more permissive [#113](https://github.com/ethyca/fideslang/pull/113)
+
+## [1.4.0](https://github.com/ethyca/fideslang/compare/1.3.4...1.4.0)
+
+### Changed
+
+- Updated the default data uses [#107](https://github.com/ethyca/fideslang/pull/107)
+
+### Removed
+
+- The `system_dependencies` field of `System` resources [#105](https://github.com/ethyca/fideslang/pull/105)
+
+## [1.3.4](https://github.com/ethyca/fideslang/compare/1.3.3...1.3.4)
 
 ### Changed
 
 - Make `PrivacyDeclaration` use pydantic `orm_mode` [#101](https://github.com/ethyca/fideslang/pull/101)
-- Updated the default data uses [#107](https://github.com/ethyca/fideslang/pull/107)
-
-### Remove
-
-- The `system_dependencies` field of `System` resources [#105](https://github.com/ethyca/fideslang/pull/105)
 
 ## [1.3.3](https://github.com/ethyca/fideslang/compare/1.3.2...1.3.3)
 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -33,7 +33,7 @@ from fideslang.validation import (
     valid_data_type,
 )
 
-# Reusable components
+# Reusable Validators
 country_code_validator = validator("third_country_transfers", allow_reuse=True)(
     check_valid_country_code
 )
@@ -45,6 +45,7 @@ no_self_reference_validator = validator("parent_key", allow_reuse=True)(
     no_self_reference
 )
 
+# Reusable Fields
 name_field = Field(description="Human-Readable name for this resource.")
 description_field = Field(
     description="A detailed description of what this resource is."
@@ -53,8 +54,8 @@ is_default_field = Field(
     default=False,
     description="Denotes whether the resource is part of the default taxonomy or not.",
 )
-
 meta_field = Field(
+    default_factory=dict,
     description="An optional property to store any extra information for a resource. Data can be structured in any way: simple set of `key: value` pairs or deeply nested objects.",
 )
 
@@ -530,10 +531,10 @@ class DatasetMetadata(BaseModel):
     after: Optional[List[FidesKey]]
 
 
-class Dataset(FidesModel, FidesopsMetaBackwardsCompat):  # type: ignore[misc]
+class Dataset(FidesModel, FidesopsMetaBackwardsCompat):
     """The Dataset resource model."""
 
-    meta: Optional[Dict[str, Any]] = meta_field  # type: ignore[misc]
+    meta: Dict = meta_field
     data_categories: Optional[List[FidesKey]] = Field(
         description="Array of Data Category resources identified by `fides_key`, that apply to all collections in the Dataset.",
     )
@@ -914,7 +915,7 @@ class DataFlow(BaseModel):
         return value
 
 
-class System(FidesModel):  # type: ignore[misc]
+class System(FidesModel):
     """
     The System resource model.
 
@@ -924,7 +925,7 @@ class System(FidesModel):  # type: ignore[misc]
     registry_id: Optional[int] = Field(
         description="The id of the system registry, if used.",
     )
-    meta: Optional[Dict[str, Any]] = meta_field  # type: ignore[misc]
+    meta: Dict = meta_field
     fidesctl_meta: Optional[SystemMetadata] = Field(
         description=SystemMetadata.__doc__,
     )

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -54,6 +54,10 @@ is_default_field = Field(
     description="Denotes whether the resource is part of the default taxonomy or not.",
 )
 
+meta_field = Field(
+    description="An optional property to store any extra information for a resource. Data can be structured in any way: simple set of `key: value` pairs or deeply nested objects.",
+)
+
 
 # Fides Base Model
 class FidesModel(BaseModel):
@@ -529,9 +533,7 @@ class DatasetMetadata(BaseModel):
 class Dataset(FidesModel, FidesopsMetaBackwardsCompat):  # type: ignore[misc]
     """The Dataset resource model."""
 
-    meta: Optional[Dict[str, Any]] = Field(  # type: ignore[misc]
-        description="An optional object that provides additional information about the Dataset. You can structure the object however you like. It can be a simple set of `key: value` properties or a deeply nested hierarchy of objects. How you use the object is up to you: Fides ignores it."
-    )
+    meta: Optional[Dict[str, Any]] = meta_field  # type: ignore[misc]
     data_categories: Optional[List[FidesKey]] = Field(
         description="Array of Data Category resources identified by `fides_key`, that apply to all collections in the Dataset.",
     )
@@ -922,9 +924,7 @@ class System(FidesModel):  # type: ignore[misc]
     registry_id: Optional[int] = Field(
         description="The id of the system registry, if used.",
     )
-    meta: Optional[Dict[str, Any]] = Field(  # type: ignore[misc]
-        description="An optional property to store any extra information for a system.",
-    )
+    meta: Optional[Dict[str, Any]] = meta_field  # type: ignore[misc]
     fidesctl_meta: Optional[SystemMetadata] = Field(
         description=SystemMetadata.__doc__,
     )

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -526,10 +526,10 @@ class DatasetMetadata(BaseModel):
     after: Optional[List[FidesKey]]
 
 
-class Dataset(FidesModel, FidesopsMetaBackwardsCompat):
+class Dataset(FidesModel, FidesopsMetaBackwardsCompat):  # type: ignore[misc]
     """The Dataset resource model."""
 
-    meta: Optional[Dict[str, str]] = Field(
+    meta: Optional[Dict[str, Any]] = Field(  # type: ignore[misc]
         description="An optional object that provides additional information about the Dataset. You can structure the object however you like. It can be a simple set of `key: value` properties or a deeply nested hierarchy of objects. How you use the object is up to you: Fides ignores it."
     )
     data_categories: Optional[List[FidesKey]] = Field(
@@ -912,7 +912,7 @@ class DataFlow(BaseModel):
         return value
 
 
-class System(FidesModel):
+class System(FidesModel):  # type: ignore[misc]
     """
     The System resource model.
 
@@ -922,8 +922,8 @@ class System(FidesModel):
     registry_id: Optional[int] = Field(
         description="The id of the system registry, if used.",
     )
-    meta: Optional[Dict[str, str]] = Field(
-        description="An optional property to store any extra information for a system. Not used by fidesctl.",
+    meta: Optional[Dict[str, Any]] = Field(  # type: ignore[misc]
+        description="An optional property to store any extra information for a system.",
     )
     fidesctl_meta: Optional[SystemMetadata] = Field(
         description=SystemMetadata.__doc__,

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -1,6 +1,6 @@
 from pytest import deprecated_call, mark, raises
 
-from fideslang import DataFlow, PrivacyDeclaration, System, Dataset
+from fideslang import DataFlow, Dataset, PrivacyDeclaration, System
 from fideslang.models import DatasetCollection, DatasetField
 
 pytestmark = mark.unit
@@ -73,6 +73,54 @@ class TestSystem:
                 )
             ],
             meta={"some": "meta stuff"},
+            name="Test System",
+            organization_fides_key=1,
+            privacy_declarations=[
+                PrivacyDeclaration(
+                    data_categories=[],
+                    data_qualifier="aggregated_data",
+                    data_subjects=[],
+                    data_use="provide",
+                    egress=["test_system_2"],
+                    ingress=["test_system_3"],
+                    name="declaration-name",
+                )
+            ],
+            registry_id=1,
+            system_type="SYSTEM",
+            tags=["some", "tags"],
+        )
+
+    def test_system_valid_nested_meta(self) -> None:
+        assert System(
+            description="Test Policy",
+            egress=[
+                DataFlow(
+                    fides_key="test_system_2",
+                    type="system",
+                    data_categories=[],
+                )
+            ],
+            fides_key="test_system",
+            ingress=[
+                DataFlow(
+                    fides_key="test_system_3",
+                    type="system",
+                    data_categories=[],
+                )
+            ],
+            meta={
+                "some": "meta stuff",
+                "some": {
+                    "nested": "meta stuff",
+                    "more nested": "meta stuff",
+                },
+                "some more": {
+                    "doubly": {
+                        "nested": "meta stuff",
+                    }
+                },
+            },
             name="Test System",
             organization_fides_key=1,
             privacy_declarations=[
@@ -208,6 +256,18 @@ class TestDataset:
     def test_valid_dataset(self):
         Dataset(
             fides_key="dataset_1",
+            meta={
+                "some": "meta stuff",
+                "some": {
+                    "nested": "meta stuff",
+                    "more nested": "meta stuff",
+                },
+                "some more": {
+                    "doubly": {
+                        "nested": "meta stuff",
+                    }
+                },
+            },
             data_qualifier="dataset_qualifier_1",
             data_categories=["dataset_data_category_1"],
             fides_meta={"after": ["other_dataset"]},

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -139,6 +139,44 @@ class TestSystem:
             tags=["some", "tags"],
         )
 
+    def test_system_valid_no_meta(self) -> None:
+        system = System(
+            description="Test Policy",
+            egress=[
+                DataFlow(
+                    fides_key="test_system_2",
+                    type="system",
+                    data_categories=[],
+                )
+            ],
+            fides_key="test_system",
+            ingress=[
+                DataFlow(
+                    fides_key="test_system_3",
+                    type="system",
+                    data_categories=[],
+                )
+            ],
+            # purposefully omitting the `meta` property to ensure it's effectively optional
+            name="Test System",
+            organization_fides_key=1,
+            privacy_declarations=[
+                PrivacyDeclaration(
+                    data_categories=[],
+                    data_qualifier="aggregated_data",
+                    data_subjects=[],
+                    data_use="provide",
+                    egress=["test_system_2"],
+                    ingress=["test_system_3"],
+                    name="declaration-name",
+                )
+            ],
+            registry_id=1,
+            system_type="SYSTEM",
+            tags=["some", "tags"],
+        )
+        assert system.meta == {}
+
     def test_system_valid_no_egress_or_ingress(self) -> None:
         assert System(
             description="Test Policy",


### PR DESCRIPTION
Closes #111 

### Code Changes

* [x] make `meta` attribute on `System` and `Dataset` models more permissive to allow for nested dictionaries/objects

### Steps to Confirm

* [x] preliminary test of fides integration [here](https://github.com/ethyca/fides/pull/3463) - looks good

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`

### Description Of Changes

see #111 for more context!
