### PR TITLE
revert meta field back to optional, default to None

### DIFF
--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -55,7 +55,7 @@ is_default_field = Field(
     description="Denotes whether the resource is part of the default taxonomy or not.",
 )
 meta_field = Field(
-    default_factory=dict,
+    default=None,
     description="An optional property to store any extra information for a resource. Data can be structured in any way: simple set of `key: value` pairs or deeply nested objects.",
 )
 
@@ -534,7 +534,7 @@ class DatasetMetadata(BaseModel):
 class Dataset(FidesModel, FidesopsMetaBackwardsCompat):
     """The Dataset resource model."""
 
-    meta: Dict = meta_field
+    meta: Optional[Dict] = meta_field
     data_categories: Optional[List[FidesKey]] = Field(
         description="Array of Data Category resources identified by `fides_key`, that apply to all collections in the Dataset.",
     )
@@ -925,7 +925,7 @@ class System(FidesModel):
     registry_id: Optional[int] = Field(
         description="The id of the system registry, if used.",
     )
-    meta: Dict = meta_field
+    meta: Optional[Dict] = meta_field
     fidesctl_meta: Optional[SystemMetadata] = Field(
         description=SystemMetadata.__doc__,
     )

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -175,7 +175,7 @@ class TestSystem:
             system_type="SYSTEM",
             tags=["some", "tags"],
         )
-        assert system.meta == {}
+        assert system.meta == None
 
     def test_system_valid_no_egress_or_ingress(self) -> None:
         assert System(


### PR DESCRIPTION
Closes n/a

We accidentally broke integrations with `fides` in https://github.com/ethyca/fideslang/pull/113 by updating the `meta` field to be not optional, but instead default to `{}` -- though the change was well motivated.

This reverts that change to keep things rolling smoothly for now. The benefit of making this update is not worth the disruption it causes on the `fides` side at this point.

### Code Changes

* [ ] revert field to be `Optional` and default to `None`

### Steps to Confirm

* [x] ensure we test integration with `fides` on this branch: https://github.com/ethyca/fides/tree/fideslang-111-integration, [see PR](https://github.com/ethyca/fides/pull/3463)

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`


