### PR TITLE
pydantic 1.10 compat

### DIFF
--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -20,9 +20,6 @@ from pydantic import (
     validator,
 )
 
-# import `Literal` from typing_extensions to work around https://github.com/pydantic/pydantic/issues/5821
-from typing_extensions import Literal
-
 from fideslang.validation import (
     FidesKey,
     check_valid_country_code,
@@ -310,7 +307,11 @@ class DatasetFieldBase(BaseModel):
     )
 
 
-EdgeDirection = Literal["from", "to"]
+class EdgeDirection(str, Enum):
+    """Direction of a FidesDataSetReference"""
+
+    FROM = "from"
+    TO = "to"
 
 
 class FidesDatasetReference(BaseModel):

--- a/src/fideslang/relationships.py
+++ b/src/fideslang/relationships.py
@@ -30,33 +30,39 @@ def find_referenced_fides_keys(resource: object) -> Set[FidesKey]:
     include the FidesKey type and return all of those values.
 
     Note that this finds _all_ fides_keys, including the resource's own fides_key
+
+    This function is used recursively for arbitrary-depth objects.
     """
     referenced_fides_keys: Set[FidesKey] = set()
+
     if isinstance(resource, str) and not isinstance(resource, Enum):
-        referenced_fides_keys.add(resource)
-        return referenced_fides_keys
+        return {resource}
+
     signature = inspect.signature(type(resource), follow_wrapped=True)
-    parameter_values = filter(
+    attributes = filter(
         lambda parameter: hasattr(resource, parameter.name),
         signature.parameters.values(),
     )
-    for parameter in parameter_values:
-        parameter_value = resource.__getattribute__(parameter.name)
-        if parameter_value:
-            if parameter.annotation == FidesKey:
-                referenced_fides_keys.add(parameter_value)
-            elif parameter.annotation == Optional[FidesKey]:
-                referenced_fides_keys.add(parameter_value)
-            elif parameter.annotation == List[FidesKey]:
-                referenced_fides_keys.update(resource.__getattribute__(parameter.name))
+
+    for attribute in attributes:
+        attribute_value = resource.__getattribute__(attribute.name)
+        if attribute_value:
+            # If it is a single FidesKey, add it directly
+            if attribute.annotation in (FidesKey, Optional[FidesKey]):
+                referenced_fides_keys.add(attribute_value)
+            # Add the list of FidesKeys to the set
+            elif attribute.annotation == List[FidesKey]:
+                referenced_fides_keys.update(resource.__getattribute__(attribute.name))
+            # If it is a list, but not of strings, recurse into each one
             elif (
-                isinstance(parameter_value, list) and parameter.annotation != List[str]
+                isinstance(attribute_value, list) and attribute.annotation != List[str]
             ):
-                nested_keys = find_nested_keys_in_list(parameter_value)
+                nested_keys = find_nested_keys_in_list(attribute_value)
                 referenced_fides_keys.update(nested_keys)
-            elif hasattr(parameter_value, "__dict__"):
+            # If it is an object, recurse this function
+            elif hasattr(attribute_value, "__dict__"):
                 referenced_fides_keys.update(
-                    find_referenced_fides_keys(parameter_value)
+                    find_referenced_fides_keys(attribute_value)
                 )
     return referenced_fides_keys
 


### PR DESCRIPTION
Closes #110 #119

### Code Changes

* [x] Refactor `EdgeDirection` model in `src/fideslang/models.py` to be a class rather than a literal
* [x] Refactor `find_referenced_fides_keys` in `src/fideslang/relationships.py` for compatibility between 1.8 -> 1.10 of pydantic

### Steps to Confirm

* [ ] Cherry-pick https://github.com/ethyca/fideslang/pull/122/commits/ddce990b8002b7f61dcda6893bb54e84e7f94f85 and run `nox`. Python 3.8, 3.9, 3.10, 3.11 will be tested with pydantic 1.8.2, 1.9.2, 1.10.9. All tests passing.

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

Caveats: 1) I am not at all an expert in typing/pydantic stuff. 2) there is a complaint from xenon that `find_referenced_fides_keys` is too complicated now.