### PR TITLE
unconstrain pyyaml, add to test matrix

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -83,6 +83,7 @@ jobs:
       matrix:
         python_version: ["3.8", "3.9", "3.10", "3.11"]
         pydantic_version: ["1.8.2", "1.9.2", "1.10.9"]
+        pyyaml_version: ["5.4.1", "6.0"]
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -99,4 +100,4 @@ jobs:
         run: pip install nox
 
       - name: Run Tests
-        run: nox -s "tests-${{ matrix.python_version }}(pydantic_version='${{ matrix.pydantic_version }}')"
+        run: nox -s "tests-${{ matrix.python_version }}(pyyaml_version='${{ matrix.pyyaml_version }}', pydantic_version='${{ matrix.pydantic_version }}')"

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,6 +5,7 @@ nox.options.reuse_existing_virtualenvs = True
 
 TESTED_PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
 TESTED_PYDANTIC_VERSIONS = ["1.8.2", "1.9.2", "1.10.9"]
+TESTED_PYYAML_VERSIONS = ["5.4.1", "6.0"]
 
 
 def install_requirements(session: nox.Session) -> None:
@@ -14,10 +15,12 @@ def install_requirements(session: nox.Session) -> None:
 
 @nox.session(python=TESTED_PYTHON_VERSIONS)
 @nox.parametrize("pydantic_version", TESTED_PYDANTIC_VERSIONS)
-def tests(session: nox.Session, pydantic_version: str) -> None:
+@nox.parametrize("pyyaml_version", TESTED_PYYAML_VERSIONS)
+def tests(session: nox.Session, pydantic_version: str, pyyaml_version: str) -> None:
     install_requirements(session)
     session.install(".")
     session.install(f"pydantic=={pydantic_version}")
+    session.install(f"pyyaml=={pyyaml_version}")
     if session.posargs:
         test_args = session.posargs
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pydantic>=1.8.1,<1.11.0
-pyyaml>=5,<6
+pyyaml>=5,<7


### PR DESCRIPTION
Closes N/A

### Code Changes

* [x] Loosen pyyaml constraint
* [x] add tests to the matrix!

### Steps to Confirm

* [ ] Observe tests passing
* [ ] Manual validation?

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`

### Description Of Changes

This unconstrains PyYAML to allow installation of 6.0 and newer releases up to 7.

Introduces the version split between 5.4.1 and 6.0 as a test matrix concern. This means that there is fairly good coverage for all runtime dependencies of fideslang, but may not be necessary as 6.0 was primarily a "drop python2.7" release for the library and fideslang currently only supports Python 3.8+