### PR TITLE
add `active` property to taxonomy classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/1.4.3...main)
 
+### Added
+
+- Add an `active` boolean property to taxonomy elements [#137](https://github.com/ethyca/fideslang/pull/137)
+
 ### Fixed
 
 - Don't allow duplicate entries for DatasetCollections as part of Datasets [#136](https://github.com/ethyca/fideslang/pull/136)

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -27,8 +27,8 @@ from fideslang.validation import (
     no_self_reference,
     parse_data_type_string,
     sort_list_objects_by_name,
-    valid_data_type,
     unique_items_in_list,
+    valid_data_type,
 )
 
 # Reusable Validators
@@ -55,6 +55,9 @@ is_default_field = Field(
 meta_field = Field(
     default=None,
     description="An optional property to store any extra information for a resource. Data can be structured in any way: simple set of `key: value` pairs or deeply nested objects.",
+)
+active_field = Field(
+    default=True, description="Indicates whether the resource is currently 'active'."
 )
 
 
@@ -164,6 +167,7 @@ class DataCategory(FidesModel):
 
     parent_key: Optional[FidesKey]
     is_default: bool = is_default_field
+    active: bool = active_field
 
     _matching_parent_key: classmethod = matching_parent_key_validator
     _no_self_reference: classmethod = no_self_reference_validator
@@ -174,6 +178,7 @@ class DataQualifier(FidesModel):
 
     parent_key: Optional[FidesKey]
     is_default: bool = is_default_field
+    active: bool = active_field
 
     _matching_parent_key: classmethod = matching_parent_key_validator
     _no_self_reference: classmethod = no_self_reference_validator
@@ -231,6 +236,7 @@ class DataSubject(FidesModel):
         description="A boolean value to annotate whether or not automated decisions/profiling exists for the data subject.",
     )
     is_default: bool = is_default_field
+    active: bool = active_field
 
 
 class DataUse(FidesModel):
@@ -258,6 +264,7 @@ class DataUse(FidesModel):
         description="A url pointing to the legitimate interest impact assessment. Required if the legal bases used is legitimate interest.",
     )
     is_default: bool = is_default_field
+    active: bool = active_field
 
     _matching_parent_key: classmethod = matching_parent_key_validator
     _no_self_reference: classmethod = no_self_reference_validator


### PR DESCRIPTION
needed for https://github.com/ethyca/fides/issues/3709

### Description Of Changes

Adds an `active` flag to the models for taxonomy elements. Flag defaults to `true`.


### Code Changes

* [x] add `active` boolean property to the taxonomy element models: `DataUse`, `DataSubject`, `DataQualifier`, `DataCategory`

### Steps to Confirm

not much here - corresponding [`fides` PR](https://github.com/ethyca/fides/pull/3784) has some actionable confirmation steps

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
