### PR TITLE
System + Privacy Declaration Dictionary Changes

### DIFF
--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -4,31 +4,19 @@
 Contains all of the Fides resources modeled as Pydantic models.
 """
 from __future__ import annotations
-from warnings import warn
+
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
+from warnings import warn
 
-from pydantic import (
-    AnyUrl,
-    BaseModel,
-    ConstrainedStr,
-    Field,
-    HttpUrl,
-    PositiveInt,
-    root_validator,
-    validator,
-)
+from pydantic import (AnyUrl, BaseModel, ConstrainedStr, Field, HttpUrl,
+                      PositiveInt, root_validator, validator)
 
-from fideslang.validation import (
-    FidesKey,
-    check_valid_country_code,
-    matching_parent_key,
-    no_self_reference,
-    parse_data_type_string,
-    sort_list_objects_by_name,
-    unique_items_in_list,
-    valid_data_type,
-)
+from fideslang.validation import (FidesKey, check_valid_country_code,
+                                  matching_parent_key, no_self_reference,
+                                  parse_data_type_string,
+                                  sort_list_objects_by_name,
+                                  unique_items_in_list, valid_data_type)
 
 # Reusable Validators
 country_code_validator = validator("third_country_transfers", allow_reuse=True)(
@@ -1011,6 +999,12 @@ class System(FidesModel):
     ingress: Optional[List[DataFlow]] = Field(
         description="The resources from which the System receives data."
     )
+    destination: Optional[List[DataFlow]] = Field(
+        description="The resources to which the System sends data."
+    )
+    source: Optional[List[DataFlow]] = Field(
+        description="The resources from which the System receives data."
+    )
     privacy_declarations: List[PrivacyDeclaration] = Field(
         description=PrivacyDeclaration.__doc__,
     )
@@ -1082,10 +1076,12 @@ class System(FidesModel):
     dpo: Optional[str] = Field(
         description="The official privacy contact address or DPO."
     )
-    joint_controller: Optional[str] = Field(
+    joint_controller: Optional[ContactDetails] = Field(
+        description=ContactDetails.__doc__,
+    )
+    joint_controller_info: Optional[str] = Field(
         description="The party or parties that share the responsibility for processing personal data."
     )
-
     data_security_practices: Optional[str] = Field(
         description="The data security practices employed by this system."
     )

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -9,14 +9,27 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 from warnings import warn
 
-from pydantic import (AnyUrl, BaseModel, ConstrainedStr, Field, HttpUrl,
-                      PositiveInt, root_validator, validator)
+from pydantic import (
+    AnyUrl,
+    BaseModel,
+    ConstrainedStr,
+    Field,
+    HttpUrl,
+    PositiveInt,
+    root_validator,
+    validator,
+)
 
-from fideslang.validation import (FidesKey, check_valid_country_code,
-                                  matching_parent_key, no_self_reference,
-                                  parse_data_type_string,
-                                  sort_list_objects_by_name,
-                                  unique_items_in_list, valid_data_type)
+from fideslang.validation import (
+    FidesKey,
+    check_valid_country_code,
+    matching_parent_key,
+    no_self_reference,
+    parse_data_type_string,
+    sort_list_objects_by_name,
+    unique_items_in_list,
+    valid_data_type,
+)
 
 # Reusable Validators
 country_code_validator = validator("third_country_transfers", allow_reuse=True)(
@@ -170,8 +183,8 @@ class SpecialCategoriesEnum(str, Enum):
 
 class SpecialCategoryLegalBasisEnum(str, Enum):
     """
-    The model for processing special categories
-    of personal data.
+    The model for the legal basis for processing special categories of personal data
+    on privacy declarations
 
     Based upon article 9 of the GDPR
     """
@@ -1183,7 +1196,7 @@ class System(FidesModel):
         values: Dict,
     ) -> PrivacyDeclaration:
         """
-        Any `PrivacyDeclaration`s which include `source` and/or `destination` fields must
+        Any `PrivacyDeclaration`s which include `egress` and/or `ingress` fields must
         only reference the `fides_key`s of defined `DataFlow`s in said field(s).
         """
 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -133,7 +133,7 @@ class LegalBasisForProcessingEnum(str, Enum):
 
     CONSENT = "Consent"
     CONTRACT = "Contract"
-    LEGAL_OBLIGATION = "Legal Obligation" # TODO: spec indicates this should now be "Legal claims" - do we update?
+    LEGAL_OBLIGATION = "Legal Obligation"  # TODO: spec indicates this should now be "Legal claims" - do we update?
     VITAL_INTEREST = "Vital Interest"
     PUBLIC_INTEREST = "Public Interest"
     LEGITIMATE_INTEREST = "Legitimate Interests"
@@ -152,7 +152,9 @@ class LegalBasisForTransfersEnum(str, Enum):
     other = "Other"
 
 
-class SpecialCategoriesEnum(str, Enum): # TODO: spec has updated friendly text here - do we need to update?
+class SpecialCategoriesEnum(
+    str, Enum
+):  # TODO: spec has updated friendly text here - do we need to update?
     """
     The model for processing special categories
     of personal data.
@@ -842,7 +844,7 @@ class PrivacyDeclaration(BaseModel):
         description="The fides key of the data qualifier describing a system in a privacy declaration.",
     )
     data_subjects: List[FidesKey] = Field(
-        default=[]
+        default=[],
         description="An array of data subjects describing a system in a privacy declaration.",
     )
     egress: Optional[List[FidesKey]] = Field(
@@ -855,8 +857,7 @@ class PrivacyDeclaration(BaseModel):
         description="Cookies associated with this data use to deliver services and functionality",
     )
     features: List[str] = Field(
-        default=[],
-        description="The features of processing personal data."
+        default=[], description="The features of processing personal data."
     )
     legal_basis_for_processing: Optional[LegalBasisForProcessingEnum] = Field(
         description="The features of processing personal data."
@@ -866,7 +867,7 @@ class PrivacyDeclaration(BaseModel):
     )
     processes_special_category_data: bool = Field(
         default=False,
-        description="The amount of time (in days) for which data is retained for this purpose."
+        description="The amount of time (in days) for which data is retained for this purpose.",
     )
     special_category: Optional[SpecialCategoriesEnum] = Field(
         description="The legal basis under which the special category data is processed.",
@@ -878,7 +879,6 @@ class PrivacyDeclaration(BaseModel):
         default=[],
         description="The categories of personal data that this system shares with third parties.",
     )
-
 
     @validator("dataset_references")
     @classmethod

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -285,23 +285,18 @@ class DataUse(FidesModel):
 
     parent_key: Optional[FidesKey] = None
     legal_basis: Optional[LegalBasisEnum] = Field(
-        default=None,
         description="Deprecated. The legal basis category of which the data use falls under. This field is used as part of the creation of an exportable data map.",
     )
     special_category: Optional[SpecialCategoriesEnum] = Field(
-        default=None,
         description="Deprecated. The special category for processing of which the data use falls under. This field is used as part of the creation of an exportable data map.",
     )
     recipients: Optional[List[str]] = Field(
-        default=None,
         description="Deprecated. An array of recipients when sharing personal data outside of your organization.",
     )
     legitimate_interest: Optional[bool] = Field(
-        default=False,
         description="Deprecated. A boolean representation of if the legal basis used is `Legitimate Interest`. Validated at run time and looks for a `legitimate_interest_impact_assessment` to exist if true.",
     )
     legitimate_interest_impact_assessment: Optional[AnyUrl] = Field(
-        default=None,
         description="Deprecated. A url pointing to the legitimate interest impact assessment. Required if the legal bases used is legitimate interest.",
     )
 
@@ -626,7 +621,6 @@ class Dataset(FidesModel, FidesopsMetaBackwardsCompat):
         description="Array of Data Category resources identified by `fides_key`, that apply to all collections in the Dataset.",
     )
     data_qualifier: Optional[FidesKey] = Field(
-        default="aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified",
         description="Deprecated. Array of Data Qualifier resources identified by `fides_key`, that apply to all collections in the Dataset.",
     )
     fides_meta: Optional[DatasetMetadata] = Field(
@@ -636,7 +630,6 @@ class Dataset(FidesModel, FidesopsMetaBackwardsCompat):
         description="Deprecated. " + ContactDetails.__doc__,
     )
     retention: Optional[str] = Field(
-        default="No retention or erasure policy",
         description="Deprecated. An optional string to describe the retention policy for a dataset. This field can also be applied more granularly at either the Collection or field level of a Dataset.",
     )
     third_country_transfers: Optional[List[str]] = Field(
@@ -913,7 +906,6 @@ class PrivacyDeclaration(BaseModel):
         description="The Data Use describing a system in a privacy declaration.",
     )
     data_qualifier: Optional[FidesKey] = Field(
-        default="aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified",
         description="Deprecated. The fides key of the data qualifier describing a system in a privacy declaration.",
     )
     data_subjects: List[FidesKey] = Field(
@@ -1076,7 +1068,6 @@ class System(FidesModel):
         description="A required value to describe the type of system being modeled, examples include: Service, Application, Third Party, etc.",
     )
     data_responsibility_title: Optional[DataResponsibilityTitle] = Field(
-        default=DataResponsibilityTitle.CONTROLLER,
         description="Deprecated. The responsibility or role over the system that processes personal data",
     )
     egress: Optional[List[DataFlow]] = Field(
@@ -1099,7 +1090,6 @@ class System(FidesModel):
         description="An optional value to identify the owning department or group of the system within your organization",
     )
     data_protection_impact_assessment: Optional[DataProtectionImpactAssessment] = Field(
-        default=DataProtectionImpactAssessment(),
         description="Deprecated. " + DataProtectionImpactAssessment.__doc__,
     )
     vendor_id: Optional[str] = Field(

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -1095,7 +1095,8 @@ class System(FidesModel):
     vendor_id: Optional[str] = Field(
         description="The unique identifier for the vendor that's associated with this system."
     )
-    dataset_references: Optional[List[FidesKey]] = Field(
+    dataset_references: List[FidesKey] = Field(
+        default_factory=list,
         description="Referenced Dataset fides keys used by the system.",
     )
     processes_personal_data: bool = Field(

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -126,7 +126,7 @@ class DataSubjectRightsEnum(str, Enum):
 
 class LegalBasisEnum(str, Enum):
     """
-    The model for allowable legal basis categories on data uses. Soon to be deprecated.
+    Deprecated. The model for allowable legal basis categories on data uses.
     """
 
     CONSENT = "Consent"
@@ -153,21 +153,25 @@ class LegalBasisForProcessingEnum(str, Enum):
 
 
 class LegalBasisForProfilingEnum(str, Enum):
-    explicit_consent = "Explicit consent"
-    contract = "Contract"
-    authorised_by_law = "Authorised by law"
+    """The model for describing the legal basis under which profiling is performed"""
+
+    EXPLICIT_CONSENT = "Explicit consent"
+    CONTRACT = "Contract"
+    AUTHORISED_BY_LAW = "Authorised by law"
 
 
 class LegalBasisForTransfersEnum(str, Enum):
-    adequacy_decision = "Adequacy decision"
-    standard_contractual_clauses = "Standard contractual clauses"
-    binding_corporate_rules = "Binding corporate rules"
-    other = "Other"
+    """The model for describing the legal basis under which data is transferred"""
+
+    ADEQUACY_DECISION = "Adequacy decision"
+    STANDARD_CONTRACTUAL_CLAUSES = "Standard contractual clauses"
+    BINDING_CORPORATE_RULES = "Binding corporate rules"
+    OTHER = "Other"
 
 
 class SpecialCategoriesEnum(str, Enum):
     """
-    Special Categories Enum that was used on Data Uses. Soon to be deprecated.
+    Deprecated. Special Categories Enum that was used on Data Uses.
     """
 
     CONSENT = "Consent"
@@ -308,7 +312,7 @@ class DataUse(FidesModel):
 
     @root_validator
     @classmethod
-    def deprecate_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    def deprecate_fields(cls, values: Dict) -> Dict:
         """
         Warn of Data Use fields pending deprecation.
         """
@@ -652,7 +656,7 @@ class Dataset(FidesModel, FidesopsMetaBackwardsCompat):
 
     @root_validator
     @classmethod
-    def deprecate_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    def deprecate_fields(cls, values: Dict) -> Dict:
         """
         Warn of Dataset fields pending deprecation.
         """
@@ -1073,7 +1077,7 @@ class System(FidesModel):
     )
     data_responsibility_title: Optional[DataResponsibilityTitle] = Field(
         default=DataResponsibilityTitle.CONTROLLER,
-        description="Deprecated. " + DataResponsibilityTitle.__doc__,
+        description="Deprecated. The responsibility or role over the system that processes personal data",
     )
     egress: Optional[List[DataFlow]] = Field(
         description="The resources to which the System sends data."
@@ -1085,7 +1089,7 @@ class System(FidesModel):
         description=PrivacyDeclaration.__doc__,
     )
     joint_controller: Optional[ContactDetails] = Field(
-        description="Deprecated." + ContactDetails.__doc__,
+        description="Deprecated. " + ContactDetails.__doc__,
     )
     third_country_transfers: Optional[List[str]] = Field(
         description="Deprecated. An optional array to identify any third countries where data is transited to. For consistency purposes, these fields are required to follow the Alpha-3 code set in ISO 3166-1.",
@@ -1170,7 +1174,7 @@ class System(FidesModel):
 
     @root_validator
     @classmethod
-    def deprecate_fields(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+    def deprecate_fields(cls, values: Dict) -> Dict:
         """
         Warn of System fields pending deprecation.
         """

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -1179,8 +1179,6 @@ class System(FidesModel):
             "third_country_transfers",
             "data_responsibility_title",
             "data_protection_impact_assessment",
-            "egress",
-            "ingress",
         ]
         for field in deprecated_fields:
             if values.get(field) is not None:

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -917,7 +917,7 @@ class PrivacyDeclaration(BaseModel):
         description="Deprecated. The fides key of the data qualifier describing a system in a privacy declaration.",
     )
     data_subjects: List[FidesKey] = Field(
-        default=[],
+        default_factory=list,
         description="An array of data subjects describing a system in a privacy declaration.",
     )
     dataset_references: Optional[List[FidesKey]] = Field(
@@ -930,7 +930,7 @@ class PrivacyDeclaration(BaseModel):
         description="The resources from which data is received. Any `fides_key`s included in this list reference `DataFlow` entries in the `ingress` array of any `System` resources to which this `PrivacyDeclaration` is applied."
     )
     features: List[str] = Field(
-        default=[], description="The features of processing personal data."
+        default_factory=list, description="The features of processing personal data."
     )
     legal_basis_for_processing: Optional[LegalBasisForProcessingEnum] = Field(
         description="The legal basis under which personal data is processed for this purpose."
@@ -948,7 +948,7 @@ class PrivacyDeclaration(BaseModel):
     special_category_legal_basis: Optional[SpecialCategoryLegalBasisEnum] = Field(
         description="The legal basis under which the special category data is processed.",
     )
-    data_shared_with_third_parties: Optional[bool] = Field(
+    data_shared_with_third_parties: bool = Field(
         default=False,
         description="This system shares data with third parties for this purpose.",
     )
@@ -956,7 +956,7 @@ class PrivacyDeclaration(BaseModel):
         description="The types of third parties the data is shared with.",
     )
     shared_categories: List[str] = Field(
-        default=[],
+        default_factory=list,
         description="The categories of personal data that this system shares with third parties.",
     )
     cookies: Optional[List[Cookies]] = Field(
@@ -1153,7 +1153,7 @@ class System(FidesModel):
         description="The legal address for the business represented by the system."
     )
     responsibility: List[DataResponsibilityTitle] = Field(
-        default=[],
+        default_factory=list,
         description=DataResponsibilityTitle.__doc__,
     )
     dpo: Optional[str] = Field(

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -27,8 +27,8 @@ from fideslang.validation import (
     no_self_reference,
     parse_data_type_string,
     sort_list_objects_by_name,
-    valid_data_type,
     unique_items_in_list,
+    valid_data_type,
 )
 
 # Reusable Validators
@@ -270,6 +270,7 @@ class DataUse(FidesModel):
         default=None,
         description="A url pointing to the legitimate interest impact assessment. Required if the legal bases used is legitimate interest.",
     )
+
     is_default: bool = is_default_field
 
     _matching_parent_key: classmethod = matching_parent_key_validator
@@ -992,8 +993,8 @@ class System(FidesModel):
     system_type: str = Field(
         description="A required value to describe the type of system being modeled, examples include: Service, Application, Third Party, etc.",
     )
-    data_responsibility_title: DataResponsibilityTitle = Field(
-        default=DataResponsibilityTitle.CONTROLLER,
+    data_responsibility_title: List[DataResponsibilityTitle] = Field(
+        default=[],
         description=DataResponsibilityTitle.__doc__,
     )
     egress: Optional[List[DataFlow]] = Field(
@@ -1070,9 +1071,6 @@ class System(FidesModel):
     )
     department: Optional[str] = Field(
         description="The department within the organization that this system belongs to."
-    )
-    responsibility: Optional[str] = Field(
-        description="The role of the business with regard to data processing."
     )
     dpo: Optional[str] = Field(
         description="The official privacy contact address or DPO."

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -111,6 +111,19 @@ class DataSubjectRightsEnum(str, Enum):
     OBJECT_TO_AUTOMATED_PROCESSING = "Object to Automated Processing"
 
 
+class LegalBasisEnum(str, Enum):
+    """
+    The model for allowable legal basis categories on Data Uses. Soon to be deprecated.
+    """
+
+    CONSENT = "Consent"
+    CONTRACT = "Contract"
+    LEGAL_OBLIGATION = "Legal Obligation"
+    VITAL_INTEREST = "Vital Interest"
+    PUBLIC_INTEREST = "Public Interest"
+    LEGITIMATE_INTEREST = "Legitimate Interests"
+
+
 class LegalBasisForProcessingEnum(str, Enum):
     """
     The model for allowable legal basis categories
@@ -140,6 +153,22 @@ class LegalBasisForTransfersEnum(str, Enum):
 
 
 class SpecialCategoriesEnum(str, Enum):
+    """
+    Old Special Categories Enum that was used on Data Uses. Soon to be deprecated.
+    """
+
+    CONSENT = "Consent"
+    EMPLOYMENT = "Employment"
+    VITAL_INTEREST = "Vital Interests"
+    NON_PROFIT_BODIES = "Non-profit Bodies"
+    PUBLIC_BY_DATA_SUBJECT = "Public by Data Subject"
+    LEGAL_CLAIMS = "Legal Claims"
+    PUBLIC_INTEREST = "Substantial Public Interest"
+    MEDICAL = "Medical"
+    PUBLIC_HEALTH_INTEREST = "Public Health Interest"
+
+
+class SpecialCategoryLegalBasisEnum(str, Enum):
     """
     The model for processing special categories
     of personal data.
@@ -238,7 +267,7 @@ class DataUse(FidesModel):
     """The DataUse resource model."""
 
     parent_key: Optional[FidesKey] = None
-    legal_basis: Optional[LegalBasisForProcessingEnum] = Field(
+    legal_basis: Optional[LegalBasisEnum] = Field(
         default=None,
         description="The legal basis category of which the data use falls under. This field is used as part of the creation of an exportable data map.",
     )
@@ -858,7 +887,7 @@ class PrivacyDeclaration(BaseModel):
         default=False,
         description="This system processes special category data",
     )
-    special_category_legal_basis: Optional[SpecialCategoriesEnum] = Field(
+    special_category_legal_basis: Optional[SpecialCategoryLegalBasisEnum] = Field(
         description="The legal basis under which the special category data is processed.",
     )
     data_shared_with_third_parties: Optional[bool] = Field(

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -9,14 +9,27 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 from warnings import warn
 
-from pydantic import (AnyUrl, BaseModel, ConstrainedStr, Field, HttpUrl,
-                      PositiveInt, root_validator, validator)
+from pydantic import (
+    AnyUrl,
+    BaseModel,
+    ConstrainedStr,
+    Field,
+    HttpUrl,
+    PositiveInt,
+    root_validator,
+    validator,
+)
 
-from fideslang.validation import (FidesKey, check_valid_country_code,
-                                  matching_parent_key, no_self_reference,
-                                  parse_data_type_string,
-                                  sort_list_objects_by_name,
-                                  unique_items_in_list, valid_data_type)
+from fideslang.validation import (
+    FidesKey,
+    check_valid_country_code,
+    matching_parent_key,
+    no_self_reference,
+    parse_data_type_string,
+    sort_list_objects_by_name,
+    unique_items_in_list,
+    valid_data_type,
+)
 
 # Reusable Validators
 country_code_validator = validator("third_country_transfers", allow_reuse=True)(
@@ -269,23 +282,23 @@ class DataUse(FidesModel):
     parent_key: Optional[FidesKey] = None
     legal_basis: Optional[LegalBasisEnum] = Field(
         default=None,
-        description="The legal basis category of which the data use falls under. This field is used as part of the creation of an exportable data map.",
+        description="Deprecated. The legal basis category of which the data use falls under. This field is used as part of the creation of an exportable data map.",
     )
     special_category: Optional[SpecialCategoriesEnum] = Field(
         default=None,
-        description="The special category for processing of which the data use falls under. This field is used as part of the creation of an exportable data map.",
+        description="Deprecated. The special category for processing of which the data use falls under. This field is used as part of the creation of an exportable data map.",
     )
     recipients: Optional[List[str]] = Field(
         default=None,
-        description="An array of recipients when sharing personal data outside of your organization.",
+        description="Deprecated. An array of recipients when sharing personal data outside of your organization.",
     )
     legitimate_interest: bool = Field(
         default=False,
-        description="A boolean representation of if the legal basis used is `Legitimate Interest`. Validated at run time and looks for a `legitimate_interest_impact_assessment` to exist if true.",
+        description="Deprecated. A boolean representation of if the legal basis used is `Legitimate Interest`. Validated at run time and looks for a `legitimate_interest_impact_assessment` to exist if true.",
     )
     legitimate_interest_impact_assessment: Optional[AnyUrl] = Field(
         default=None,
-        description="A url pointing to the legitimate interest impact assessment. Required if the legal bases used is legitimate interest.",
+        description="Deprecated. A url pointing to the legitimate interest impact assessment. Required if the legal bases used is legitimate interest.",
     )
 
     is_default: bool = is_default_field
@@ -589,20 +602,20 @@ class Dataset(FidesModel, FidesopsMetaBackwardsCompat):
     )
     data_qualifier: FidesKey = Field(
         default="aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified",
-        description="Array of Data Qualifier resources identified by `fides_key`, that apply to all collections in the Dataset.",
+        description="Deprecated. Array of Data Qualifier resources identified by `fides_key`, that apply to all collections in the Dataset.",
     )
     fides_meta: Optional[DatasetMetadata] = Field(
         description=DatasetMetadata.__doc__, default=None
     )
     joint_controller: Optional[ContactDetails] = Field(
-        description=ContactDetails.__doc__,
+        description="Deprecated. " + ContactDetails.__doc__,
     )
     retention: Optional[str] = Field(
         default="No retention or erasure policy",
-        description="An optional string to describe the retention policy for a dataset. This field can also be applied more granularly at either the Collection or field level of a Dataset.",
+        description="Deprecated. An optional string to describe the retention policy for a dataset. This field can also be applied more granularly at either the Collection or field level of a Dataset.",
     )
     third_country_transfers: Optional[List[str]] = Field(
-        description="An optional array to identify any third countries where data is transited to. For consistency purposes, these fields are required to follow the Alpha-3 code set in [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3).",
+        description="Deprecated. An optional array to identify any third countries where data is transited to. For consistency purposes, these fields are required to follow the Alpha-3 code set in [ISO 3166-1](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3).",
     )
     collections: List[DatasetCollection] = Field(
         description="An array of objects that describe the Dataset's collections.",
@@ -856,14 +869,14 @@ class PrivacyDeclaration(BaseModel):
     )
     data_qualifier: FidesKey = Field(
         default="aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified",
-        description="The fides key of the data qualifier describing a system in a privacy declaration.",
+        description="Deprecated. The fides key of the data qualifier describing a system in a privacy declaration.",
     )
     data_subjects: List[FidesKey] = Field(
         default=[],
         description="An array of data subjects describing a system in a privacy declaration.",
     )
     dataset_references: Optional[List[FidesKey]] = Field(
-        description="Referenced Dataset fides keys used by the system.",
+        description="Deprecated. Referenced Dataset fides keys used by the system.",
     )
     egress: Optional[List[FidesKey]] = Field(
         description="The resources to which data is sent. Any `fides_key`s included in this list reference `DataFlow` entries in the `egress` array of any `System` resources to which this `PrivacyDeclaration` is applied."
@@ -1020,13 +1033,13 @@ class System(FidesModel):
     )
     data_responsibility_title: DataResponsibilityTitle = Field(
         default=DataResponsibilityTitle.CONTROLLER,
-        description=DataResponsibilityTitle.__doc__,
+        description="Deprecated. " + DataResponsibilityTitle.__doc__,
     )
     egress: Optional[List[DataFlow]] = Field(
-        description="The resources to which the System sends data."
+        description="Deprecated. The resources to which the System sends data."
     )
     ingress: Optional[List[DataFlow]] = Field(
-        description="The resources from which the System receives data."
+        description="Deprecated. The resources from which the System receives data."
     )
     destination: Optional[List[DataFlow]] = Field(
         description="The resources to which the System sends data."
@@ -1038,7 +1051,7 @@ class System(FidesModel):
         description=PrivacyDeclaration.__doc__,
     )
     third_country_transfers: Optional[List[str]] = Field(
-        description="An optional array to identify any third countries where data is transited to. For consistency purposes, these fields are required to follow the Alpha-3 code set in ISO 3166-1.",
+        description="Deprecated. An optional array to identify any third countries where data is transited to. For consistency purposes, these fields are required to follow the Alpha-3 code set in ISO 3166-1.",
     )
     administrating_department: Optional[str] = Field(
         default="Not defined",
@@ -1046,7 +1059,7 @@ class System(FidesModel):
     )
     data_protection_impact_assessment: DataProtectionImpactAssessment = Field(
         default=DataProtectionImpactAssessment(),
-        description=DataProtectionImpactAssessment.__doc__,
+        description="Deprecated. " + DataProtectionImpactAssessment.__doc__,
     )
     vendor_id: Optional[str] = Field(
         description="The unique identifier for the vendor that's associated with this system."
@@ -1106,8 +1119,9 @@ class System(FidesModel):
         description="The official privacy contact address or DPO."
     )
     joint_controller: Optional[ContactDetails] = Field(
-        description=ContactDetails.__doc__,
+        description="Deprecated. The party or parties that share the responsibility for processing personal data."
     )
+
     joint_controller_info: Optional[str] = Field(
         description="The party or parties that share the responsibility for processing personal data."
     )

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -577,6 +577,9 @@ class Dataset(FidesModel, FidesopsMetaBackwardsCompat):
     fides_meta: Optional[DatasetMetadata] = Field(
         description=DatasetMetadata.__doc__, default=None
     )
+    joint_controller: Optional[ContactDetails] = Field(
+        description=ContactDetails.__doc__,
+    )
     retention: Optional[str] = Field(
         default="No retention or erasure policy",
         description="An optional string to describe the retention policy for a dataset. This field can also be applied more granularly at either the Collection or field level of a Dataset.",
@@ -857,6 +860,9 @@ class PrivacyDeclaration(BaseModel):
     legal_basis_for_processing: Optional[LegalBasisForProcessingEnum] = Field(
         description="The legal basis under which personal data is processed for this purpose."
     )
+    impact_assessment_location: Optional[str] = Field(
+        description="Where the legitimate interest impact assessment is stored"
+    )
     retention_period: Optional[int] = Field(
         description="The amount of time (in days) for which data is retained for this purpose."
     )
@@ -1040,9 +1046,8 @@ class System(FidesModel):
         default=False,
         description="Whether the vendor uses data to profile a consumer in a way that has a legal effect.",
     )
-    legal_basis_for_profiling: List[LegalBasisForProfilingEnum] = Field(
+    legal_basis_for_profiling: Optional[LegalBasisForProfilingEnum] = Field(
         description="The legal basis for performing profiling that has a legal effect.",
-        default=[],
     )
     does_international_transfers: bool = Field(
         default=False,

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -9,27 +9,14 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 from warnings import warn
 
-from pydantic import (
-    AnyUrl,
-    BaseModel,
-    ConstrainedStr,
-    Field,
-    HttpUrl,
-    PositiveInt,
-    root_validator,
-    validator,
-)
+from pydantic import (AnyUrl, BaseModel, ConstrainedStr, Field, HttpUrl,
+                      PositiveInt, root_validator, validator)
 
-from fideslang.validation import (
-    FidesKey,
-    check_valid_country_code,
-    matching_parent_key,
-    no_self_reference,
-    parse_data_type_string,
-    sort_list_objects_by_name,
-    unique_items_in_list,
-    valid_data_type,
-)
+from fideslang.validation import (FidesKey, check_valid_country_code,
+                                  matching_parent_key, no_self_reference,
+                                  parse_data_type_string,
+                                  sort_list_objects_by_name,
+                                  unique_items_in_list, valid_data_type)
 
 # Reusable Validators
 country_code_validator = validator("third_country_transfers", allow_reuse=True)(
@@ -292,7 +279,7 @@ class DataUse(FidesModel):
         default=None,
         description="Deprecated. An array of recipients when sharing personal data outside of your organization.",
     )
-    legitimate_interest: bool = Field(
+    legitimate_interest: Optional[bool] = Field(
         default=False,
         description="Deprecated. A boolean representation of if the legal basis used is `Legitimate Interest`. Validated at run time and looks for a `legitimate_interest_impact_assessment` to exist if true.",
     )
@@ -621,7 +608,7 @@ class Dataset(FidesModel, FidesopsMetaBackwardsCompat):
     data_categories: Optional[List[FidesKey]] = Field(
         description="Array of Data Category resources identified by `fides_key`, that apply to all collections in the Dataset.",
     )
-    data_qualifier: FidesKey = Field(
+    data_qualifier: Optional[FidesKey] = Field(
         default="aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified",
         description="Deprecated. Array of Data Qualifier resources identified by `fides_key`, that apply to all collections in the Dataset.",
     )
@@ -908,7 +895,7 @@ class PrivacyDeclaration(BaseModel):
     data_use: FidesKey = Field(
         description="The Data Use describing a system in a privacy declaration.",
     )
-    data_qualifier: FidesKey = Field(
+    data_qualifier: Optional[FidesKey] = Field(
         default="aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified",
         description="Deprecated. The fides key of the data qualifier describing a system in a privacy declaration.",
     )
@@ -1071,7 +1058,7 @@ class System(FidesModel):
     system_type: str = Field(
         description="A required value to describe the type of system being modeled, examples include: Service, Application, Third Party, etc.",
     )
-    data_responsibility_title: DataResponsibilityTitle = Field(
+    data_responsibility_title: Optional[DataResponsibilityTitle] = Field(
         default=DataResponsibilityTitle.CONTROLLER,
         description="Deprecated. " + DataResponsibilityTitle.__doc__,
     )
@@ -1094,7 +1081,7 @@ class System(FidesModel):
         default="Not defined",
         description="An optional value to identify the owning department or group of the system within your organization",
     )
-    data_protection_impact_assessment: DataProtectionImpactAssessment = Field(
+    data_protection_impact_assessment: Optional[DataProtectionImpactAssessment] = Field(
         default=DataProtectionImpactAssessment(),
         description="Deprecated. " + DataProtectionImpactAssessment.__doc__,
     )

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -934,8 +934,8 @@ class PrivacyDeclaration(BaseModel):
     impact_assessment_location: Optional[str] = Field(
         description="Where the legitimate interest impact assessment is stored"
     )
-    retention_period: Optional[int] = Field(
-        description="The amount of time (in days) for which data is retained for this purpose."
+    retention_period: Optional[str] = Field(
+        description="An optional string to describe the time period for which data is retained for this purpose."
     )
     processes_special_category_data: bool = Field(
         default=False,

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -1,6 +1,7 @@
 from pytest import deprecated_call, mark, raises
 
-from fideslang import DataFlow, Dataset, Organization, PrivacyDeclaration, System
+from fideslang import (DataFlow, Dataset, Organization, PrivacyDeclaration,
+                       System)
 from fideslang.models import ContactDetails, DatasetCollection, DatasetField
 
 pytestmark = mark.unit
@@ -70,19 +71,6 @@ class TestPrivacyDeclaration:
             ingress=[],
             name="declaration-name",
         )
-
-    def test_dataset_references_deprecation(self) -> None:
-        with deprecated_call(match="dataset_references"):
-            assert PrivacyDeclaration(
-                data_categories=[],
-                data_qualifier="aggregated_data",
-                data_subjects=[],
-                data_use="provide",
-                dataset_references=[],
-                egress=["test_system_2"],
-                ingress=["test_system_3"],
-                name="declaration-name",
-            )
 
 
 class TestSystem:
@@ -323,6 +311,91 @@ class TestSystem:
             registry_id=1,
             system_type="SYSTEM",
             tags=["some", "tags"],
+        )
+
+    def test_expanded_system(self):
+        assert System(
+            fides_key="test_system",
+            organization_fides_key=1,
+            tags=["some", "tags"],
+            name="Exponential Interactive, Inc d/b/a VDX.tv",
+            description="My system test",
+            registry_id=1,
+            meta={"some": "meta stuff"},
+            system_type="SYSTEM",
+            egress=[
+                DataFlow(
+                    fides_key="test_system_2",
+                    type="system",
+                    data_categories=[],
+                )
+            ],
+            ingress=[
+                DataFlow(
+                    fides_key="test_system_3",
+                    type="system",
+                    data_categories=[],
+                )
+            ],
+            privacy_declarations=[
+                PrivacyDeclaration(
+                    name="declaration-name",
+                    data_categories=[
+                        "user.device.ip_address",
+                        "user.device.cookie_id",
+                        "user.device.device_id",
+                        "user.id.pseudonymous",
+                        "user.behavior.purchase_history",
+                        "user.behavior",
+                        "user.behavior.browsing_history",
+                        "user.behavior.media_consumption",
+                        "user.behavior.search_history",
+                        "user.location.imprecise",
+                        "user.demographic",
+                        "user.privacy_preferences",
+                    ],
+                    data_qualifier="aggregated_data",
+                    data_use="functional.storage",
+                    data_subjects=[],
+                    egress=["test_system_2"],
+                    ingress=["test_system_3"],
+                    features=[
+                        "Match and combine offline data sources",
+                        "Link different devices",
+                        "Receive and use automatically-sent device characteristics for identification",
+                    ],
+                    legal_basis_for_processing="Consent",
+                    retention_period=387,
+                    processes_special_category_data=False,
+                    special_category_legal_basis=None,
+                    data_shared_with_third_parties=True,
+                    third_parties="advertising",
+                    shared_categories=[],
+                    cookies=[
+                        {"name": "ANON_ID", "path": "/", "domain": "tribalfusion.com"}
+                    ],
+                )
+            ],
+            third_country_transfers=["ARM"],
+            administrating_department="Not defined",
+            vendor_id="1",
+            processes_personal_data=True,
+            exempt_from_privacy_regulations=False,
+            reason_for_exemption=None,
+            uses_profiling=False,
+            legal_basis_for_profiling=[],
+            does_international_transfers=True,
+            legal_basis_for_transfers="Standard contractual clauses",
+            requires_data_protection_assessments=False,
+            dpa_location=None,
+            privacy_policy="https://vdx.tv/privacy/",
+            legal_name="Exponential Interactive, Inc d/b/a VDX.tv",
+            legal_address="Exponential Interactive Spain S.L.;General Martinez Campos Num 41;Madrid;28010;Spain",
+            department="Privacy Department",
+            data_responsibility_title=["Controller"],
+            dpo="privacyofficertest@vdx.tv",
+            data_security_practices=None,
+            cookies=[{"name": "test_cookie"}],
         )
 
 

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -1,8 +1,12 @@
 from pytest import deprecated_call, mark, raises
 
-from fideslang import (DataFlow, Dataset, Organization, PrivacyDeclaration,
-                       System)
-from fideslang.models import ContactDetails, DatasetCollection, DatasetField
+from fideslang import DataFlow, Dataset, Organization, PrivacyDeclaration, System
+from fideslang.models import (
+    ContactDetails,
+    DatasetCollection,
+    DatasetField,
+    DataResponsibilityTitle,
+)
 
 pytestmark = mark.unit
 
@@ -71,6 +75,19 @@ class TestPrivacyDeclaration:
             ingress=[],
             name="declaration-name",
         )
+
+    def test_dataset_references_deprecation(self) -> None:
+        with deprecated_call(match="dataset_references"):
+            assert PrivacyDeclaration(
+                data_categories=[],
+                data_qualifier="aggregated_data",
+                data_subjects=[],
+                data_use="provide",
+                dataset_references=[],
+                egress=["test_system_2"],
+                ingress=["test_system_3"],
+                name="declaration-name",
+            )
 
 
 class TestSystem:
@@ -392,7 +409,7 @@ class TestSystem:
             legal_name="Exponential Interactive, Inc d/b/a VDX.tv",
             legal_address="Exponential Interactive Spain S.L.;General Martinez Campos Num 41;Madrid;28010;Spain",
             department="Privacy Department",
-            data_responsibility_title=["Controller"],
+            responsibility=[DataResponsibilityTitle.CONTROLLER],
             dpo="privacyofficertest@vdx.tv",
             data_security_practices=None,
             cookies=[{"name": "test_cookie"}],

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -77,7 +77,7 @@ class TestPrivacyDeclaration:
             name="declaration-name",
         )
 
-    def test_dataset_data_qualifier_deprecation(self) -> None:
+    def test_privacy_declaration_data_qualifier_deprecation(self) -> None:
         with deprecated_call(match="data_qualifier"):
             assert PrivacyDeclaration(
                 data_categories=[],
@@ -417,65 +417,42 @@ class TestSystem:
             cookies=[{"name": "test_cookie"}],
         )
 
-    def test_system_data_responsibility_title_deprecation(self) -> None:
-        with deprecated_call(match="data_responsibility_title"):
-            assert System(
-                description="Test Policy",
-                fides_key="test_system",
-                name="Test System",
-                registry_id=1,
-                system_type="SYSTEM",
-                tags=["some", "tags"],
-                privacy_declarations=[],
-                data_responsiblity_title="Controller",
-            )
-
-    def test_joint_controller_deprecation(self) -> None:
-        with deprecated_call(match="joint_controller"):
-            assert System(
-                description="Test Policy",
-                fides_key="test_system",
-                name="Test System",
-                registry_id=1,
-                system_type="SYSTEM",
-                tags=["some", "tags"],
-                privacy_declarations=[],
-                joint_controller={
+    @mark.parametrize(
+        "deprecated_field,value",
+        [
+            ("data_responsibility_title", "Controller"),
+            (
+                "joint_controller",
+                {
                     "name": "Jane Doe",
                     "address": "104 Test Lane; Test Town, TX, 32522",
                     "email": "jane@example.com",
                     "phone": "345-255-2555",
                 },
-            )
-
-    def test_system_third_country_transfers_deprecation(self) -> None:
-        with deprecated_call(match="third_country_transfers"):
-            assert System(
-                description="Test Policy",
-                fides_key="test_system",
-                name="Test System",
-                registry_id=1,
-                system_type="SYSTEM",
-                tags=["some", "tags"],
-                privacy_declarations=[],
-                third_country_transfers=["GBR"],
-            )
-
-    def test_system_data_protection_impact_assessment_deprecation(self) -> None:
-        with deprecated_call(match="data_protection_impact_assessment"):
-            assert System(
-                description="Test Policy",
-                fides_key="test_system",
-                name="Test System",
-                registry_id=1,
-                system_type="SYSTEM",
-                tags=["some", "tags"],
-                privacy_declarations=[],
-                data_protection_impact_assessment={
+            ),
+            ("third_country_transfers", ["GBR"]),
+            (
+                "data_protection_impact_assessment",
+                {
                     "is_required": True,
                     "progress": "pending",
                     "link": "https://www.example.com/dpia",
                 },
+            ),
+        ],
+    )
+    def test_system_deprecated_fields(self, deprecated_field, value) -> None:
+        with deprecated_call(match=deprecated_field):
+            assert System(
+                **{
+                    "description": "Test System",
+                    "fides_key": "test_system",
+                    "name": "Test System",
+                    "registry": 1,
+                    "system_type": "SYSTEM",
+                    "privacy_declarations": [],
+                    deprecated_field: value,
+                }
             )
 
 
@@ -544,36 +521,23 @@ class TestDataset:
             ],
         )
 
-    def test_dataset_data_qualifier_deprecation(self) -> None:
-        with deprecated_call(match="data_qualifier"):
+    @mark.parametrize(
+        "deprecated_field,value",
+        [
+            ("data_qualifier", "dataset_qualifier_1"),
+            ("joint_controller", {"name": "Controller_name"}),
+            ("retention", "90 days"),
+            ("third_country_transfers", ["IRL"]),
+        ],
+    )
+    def test_dataset_deprecated_fields(self, deprecated_field, value) -> None:
+        with deprecated_call(match=deprecated_field):
             assert Dataset(
-                fides_key="new_dataset",
-                collections=[],
-                data_qualifier="dataset_qualifier_1",
-            )
-
-    def test_dataset_joint_controller_deprecation(self) -> None:
-        with deprecated_call(match="joint_controller"):
-            assert Dataset(
-                fides_key="new_dataset",
-                collections=[],
-                joint_controller={"name": "Controller_name"},
-            )
-
-    def test_dataset_retention_deprecation(self) -> None:
-        with deprecated_call(match="retention"):
-            assert Dataset(
-                fides_key="new_dataset",
-                collections=[],
-                retention="90 days",
-            )
-
-    def test_dataset_third_country_transfers_deprecation(self) -> None:
-        with deprecated_call(match="retention"):
-            assert Dataset(
-                fides_key="new_dataset",
-                collections=[],
-                third_country_transfers=["IRL"],
+                **{
+                    "fides_key": "test_dataset",
+                    "collections": [],
+                    deprecated_field: value,
+                }
             )
 
 
@@ -581,31 +545,16 @@ class TestDataUse:
     def test_minimal_data_use(self):
         assert DataUse(fides_key="new_use")
 
-    def test_data_use_legal_basis_deprecation(self) -> None:
-        with deprecated_call(match="legal_basis"):
-            assert DataUse(fides_key="new_use", legal_basis="Legal Obligation")
-
-    def test_data_use_special_category_deprecation(self) -> None:
-        with deprecated_call(match="special_category"):
-            assert DataUse(
-                fides_key="new_use", special_category="Substantial Public Interest"
-            )
-
-    def test_data_use_recipients_deprecation(self) -> None:
-        with deprecated_call(match="recipients"):
-            assert DataUse(fides_key="new_use", recipients=["Advertising Bureau"])
-
-    def test_data_use_legitimate_interest_deprecation(self) -> None:
-        with deprecated_call(match="legitimate_interest"):
-            assert DataUse(
-                fides_key="new_use",
-                legitimate_interest=True,
-                legitimate_interest_impact_assessment="https://www.example.com",
-            )
-
-    def test_data_use_legitimate_interest_impact_assessment_deprecation(self) -> None:
-        with deprecated_call(match="legitimate_interest_impact_assessment"):
-            assert DataUse(
-                fides_key="new_use",
-                legitimate_interest_impact_assessment="https://www.example.com",
-            )
+    @mark.parametrize(
+        "deprecated_field,value",
+        [
+            ("legal_basis", "Legal Obligation"),
+            ("special_category", "Substantial Public Interest"),
+            ("recipients", ["Advertising Bureau"]),
+            ("legitimate_interest", False),
+            ("legitimate_interest_impact_assessment", "https://www.example.com"),
+        ],
+    )
+    def test_datause_deprecated_fields(self, deprecated_field, value) -> None:
+        with deprecated_call(match=deprecated_field):
+            assert DataUse(**{"fides_key": "new_use", deprecated_field: value})

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -1,9 +1,13 @@
 from pytest import deprecated_call, mark, raises
 
-from fideslang import (DataFlow, Dataset, Organization, PrivacyDeclaration,
-                       System)
-from fideslang.models import (ContactDetails, DataResponsibilityTitle,
-                              DatasetCollection, DatasetField)
+from fideslang import DataFlow, Dataset, Organization, PrivacyDeclaration, System
+from fideslang.models import (
+    ContactDetails,
+    DataResponsibilityTitle,
+    DatasetCollection,
+    DatasetField,
+    DataUse,
+)
 
 pytestmark = mark.unit
 
@@ -381,10 +385,10 @@ class TestSystem:
                     legal_basis_for_processing="Legitimate interests",
                     impact_assessment_location="www.example.com/impact_asessment_location",
                     retention_period=387,
-                    processes_special_category_data=False,
-                    special_category_legal_basis=None,
+                    processes_special_category_data=True,
+                    special_category_legal_basis="Reasons of substantial public interest (with a basis in law)",
                     data_shared_with_third_parties=True,
-                    third_parties="advertising",
+                    third_parties="advertising; marketing",
                     shared_categories=[],
                     cookies=[
                         {"name": "ANON_ID", "path": "/", "domain": "tribalfusion.com"}
@@ -392,7 +396,6 @@ class TestSystem:
                 )
             ],
             third_country_transfers=["ARM"],
-            administrating_department="Not defined",
             vendor_id="1",
             dataset_references=["test_fides_key_dataset"],
             processes_personal_data=True,
@@ -407,12 +410,73 @@ class TestSystem:
             privacy_policy="https://vdx.tv/privacy/",
             legal_name="Exponential Interactive, Inc d/b/a VDX.tv",
             legal_address="Exponential Interactive Spain S.L.;General Martinez Campos Num 41;Madrid;28010;Spain",
-            department="Privacy Department",
+            administrating_department="Privacy Department",
             responsibility=[DataResponsibilityTitle.CONTROLLER],
             dpo="privacyofficertest@vdx.tv",
             data_security_practices=None,
             cookies=[{"name": "test_cookie"}],
         )
+
+    def test_system_data_responsibility_title_deprecation(self) -> None:
+        with deprecated_call(match="data_responsibility_title"):
+            assert System(
+                description="Test Policy",
+                fides_key="test_system",
+                name="Test System",
+                registry_id=1,
+                system_type="SYSTEM",
+                tags=["some", "tags"],
+                privacy_declarations=[],
+                data_responsiblity_title="Controller",
+            )
+
+    def test_joint_controller_deprecation(self) -> None:
+        with deprecated_call(match="joint_controller"):
+            assert System(
+                description="Test Policy",
+                fides_key="test_system",
+                name="Test System",
+                registry_id=1,
+                system_type="SYSTEM",
+                tags=["some", "tags"],
+                privacy_declarations=[],
+                joint_controller={
+                    "name": "Jane Doe",
+                    "address": "104 Test Lane; Test Town, TX, 32522",
+                    "email": "jane@example.com",
+                    "phone": "345-255-2555",
+                },
+            )
+
+    def test_system_third_country_transfers_deprecation(self) -> None:
+        with deprecated_call(match="third_country_transfers"):
+            assert System(
+                description="Test Policy",
+                fides_key="test_system",
+                name="Test System",
+                registry_id=1,
+                system_type="SYSTEM",
+                tags=["some", "tags"],
+                privacy_declarations=[],
+                third_country_transfers=["GBR"],
+            )
+
+    def test_system_data_protection_impact_assessment_deprecation(self) -> None:
+        with deprecated_call(match="data_protection_impact_assessment"):
+            assert System(
+                description="Test Policy",
+                fides_key="test_system",
+                name="Test System",
+                registry_id=1,
+                system_type="SYSTEM",
+                tags=["some", "tags"],
+                privacy_declarations=[],
+                data_protection_impact_assessment={
+                    "is_required": True,
+                    "progress": "pending",
+                    "link": "https://www.example.com/dpia",
+                },
+            )
 
 
 class TestDataset:
@@ -479,3 +543,69 @@ class TestDataset:
                 ),
             ],
         )
+
+    def test_dataset_data_qualifier_deprecation(self) -> None:
+        with deprecated_call(match="data_qualifier"):
+            assert Dataset(
+                fides_key="new_dataset",
+                collections=[],
+                data_qualifier="dataset_qualifier_1",
+            )
+
+    def test_dataset_joint_controller_deprecation(self) -> None:
+        with deprecated_call(match="joint_controller"):
+            assert Dataset(
+                fides_key="new_dataset",
+                collections=[],
+                joint_controller={"name": "Controller_name"},
+            )
+
+    def test_dataset_retention_deprecation(self) -> None:
+        with deprecated_call(match="retention"):
+            assert Dataset(
+                fides_key="new_dataset",
+                collections=[],
+                retention="90 days",
+            )
+
+    def test_dataset_third_country_transfers_deprecation(self) -> None:
+        with deprecated_call(match="retention"):
+            assert Dataset(
+                fides_key="new_dataset",
+                collections=[],
+                third_country_transfers=["IRL"],
+            )
+
+
+class TestDataUse:
+    def test_minimal_data_use(self):
+        assert DataUse(fides_key="new_use")
+
+    def test_data_use_legal_basis_deprecation(self) -> None:
+        with deprecated_call(match="legal_basis"):
+            assert DataUse(fides_key="new_use", legal_basis="Legal Obligation")
+
+    def test_data_use_special_category_deprecation(self) -> None:
+        with deprecated_call(match="special_category"):
+            assert DataUse(
+                fides_key="new_use", special_category="Substantial Public Interest"
+            )
+
+    def test_data_use_recipients_deprecation(self) -> None:
+        with deprecated_call(match="recipients"):
+            assert DataUse(fides_key="new_use", recipients=["Advertising Bureau"])
+
+    def test_data_use_legitimate_interest_deprecation(self) -> None:
+        with deprecated_call(match="legitimate_interest"):
+            assert DataUse(
+                fides_key="new_use",
+                legitimate_interest=True,
+                legitimate_interest_impact_assessment="https://www.example.com",
+            )
+
+    def test_data_use_legitimate_interest_impact_assessment_deprecation(self) -> None:
+        with deprecated_call(match="legitimate_interest_impact_assessment"):
+            assert DataUse(
+                fides_key="new_use",
+                legitimate_interest_impact_assessment="https://www.example.com",
+            )

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -384,7 +384,7 @@ class TestSystem:
                     ],
                     legal_basis_for_processing="Legitimate interests",
                     impact_assessment_location="www.example.com/impact_asessment_location",
-                    retention_period=387,
+                    retention_period="3-5 years",
                     processes_special_category_data=True,
                     special_category_legal_basis="Reasons of substantial public interest (with a basis in law)",
                     data_shared_with_third_parties=True,

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -1,12 +1,9 @@
 from pytest import deprecated_call, mark, raises
 
-from fideslang import DataFlow, Dataset, Organization, PrivacyDeclaration, System
-from fideslang.models import (
-    ContactDetails,
-    DatasetCollection,
-    DatasetField,
-    DataResponsibilityTitle,
-)
+from fideslang import (DataFlow, Dataset, Organization, PrivacyDeclaration,
+                       System)
+from fideslang.models import (ContactDetails, DataResponsibilityTitle,
+                              DatasetCollection, DatasetField)
 
 pytestmark = mark.unit
 
@@ -76,8 +73,8 @@ class TestPrivacyDeclaration:
             name="declaration-name",
         )
 
-    def test_dataset_references_deprecation(self) -> None:
-        with deprecated_call(match="dataset_references"):
+    def test_dataset_data_qualifier_deprecation(self) -> None:
+        with deprecated_call(match="data_qualifier"):
             assert PrivacyDeclaration(
                 data_categories=[],
                 data_qualifier="aggregated_data",
@@ -381,7 +378,8 @@ class TestSystem:
                         "Link different devices",
                         "Receive and use automatically-sent device characteristics for identification",
                     ],
-                    legal_basis_for_processing="Consent",
+                    legal_basis_for_processing="Legitimate interests",
+                    impact_assessment_location="www.example.com/impact_asessment_location",
                     retention_period=387,
                     processes_special_category_data=False,
                     special_category_legal_basis=None,
@@ -396,15 +394,16 @@ class TestSystem:
             third_country_transfers=["ARM"],
             administrating_department="Not defined",
             vendor_id="1",
+            dataset_references=["test_fides_key_dataset"],
             processes_personal_data=True,
             exempt_from_privacy_regulations=False,
             reason_for_exemption=None,
-            uses_profiling=False,
-            legal_basis_for_profiling=[],
+            uses_profiling=True,
+            legal_basis_for_profiling="Explicit consent",
             does_international_transfers=True,
             legal_basis_for_transfers="Standard contractual clauses",
-            requires_data_protection_assessments=False,
-            dpa_location=None,
+            requires_data_protection_assessments=True,
+            dpa_location="www.example.com/dpa_location",
             privacy_policy="https://vdx.tv/privacy/",
             legal_name="Exponential Interactive, Inc d/b/a VDX.tv",
             legal_address="Exponential Interactive Spain S.L.;General Martinez Campos Num 41;Madrid;28010;Spain",

--- a/tests/fideslang/test_relationships.py
+++ b/tests/fideslang/test_relationships.py
@@ -1,23 +1,11 @@
 import pytest
 
 from fideslang import relationships
-from fideslang.models import (
-    ContactDetails,
-    DataCategory,
-    DataFlow,
-    DataProtectionImpactAssessment,
-    Dataset,
-    DatasetCollection,
-    DatasetField,
-    DataUse,
-    MatchesEnum,
-    Organization,
-    Policy,
-    PolicyRule,
-    PrivacyDeclaration,
-    System,
-    Taxonomy,
-)
+from fideslang.models import (ContactDetails, DataCategory, DataFlow,
+                              DataProtectionImpactAssessment, Dataset,
+                              DatasetCollection, DatasetField, DataUse,
+                              MatchesEnum, Organization, Policy, PolicyRule,
+                              PrivacyDeclaration, System, Taxonomy)
 
 
 @pytest.mark.unit
@@ -131,8 +119,8 @@ class TestFindReferencedKeys:
             name="Direct Marketing",
             description="User information for direct marketing purposes",
             recipients=["Processor - marketing co."],
-            legal_basis="Legitimate interests",
-            special_category="Vital interests",
+            legal_basis="Legitimate Interests",
+            special_category="Vital Interests",
             legitimate_interest_impact_assessment="https://example.org/legitimate_interest_assessment",
             parent_key=None,
         )

--- a/tests/fideslang/test_relationships.py
+++ b/tests/fideslang/test_relationships.py
@@ -131,8 +131,8 @@ class TestFindReferencedKeys:
             name="Direct Marketing",
             description="User information for direct marketing purposes",
             recipients=["Processor - marketing co."],
-            legal_basis="Legitimate Interests",
-            special_category="Vital Interests",
+            legal_basis="Legitimate interests",
+            special_category="Vital interests",
             legitimate_interest_impact_assessment="https://example.org/legitimate_interest_assessment",
             parent_key=None,
         )

--- a/tests/fideslang/test_relationships.py
+++ b/tests/fideslang/test_relationships.py
@@ -1,11 +1,23 @@
 import pytest
 
 from fideslang import relationships
-from fideslang.models import (ContactDetails, DataCategory, DataFlow,
-                              DataProtectionImpactAssessment, Dataset,
-                              DatasetCollection, DatasetField, DataUse,
-                              MatchesEnum, Organization, Policy, PolicyRule,
-                              PrivacyDeclaration, System, Taxonomy)
+from fideslang.models import (
+    ContactDetails,
+    DataCategory,
+    DataFlow,
+    DataProtectionImpactAssessment,
+    Dataset,
+    DatasetCollection,
+    DatasetField,
+    DataUse,
+    MatchesEnum,
+    Organization,
+    Policy,
+    PolicyRule,
+    PrivacyDeclaration,
+    System,
+    Taxonomy,
+)
 
 
 @pytest.mark.unit

--- a/tests/fideslang/test_validation.py
+++ b/tests/fideslang/test_validation.py
@@ -20,11 +20,7 @@ from fideslang.models import (
     PrivacyRule,
     System,
 )
-from fideslang.validation import (
-    FidesKey,
-    FidesValidationError,
-    valid_data_type,
-)
+from fideslang.validation import FidesKey, FidesValidationError, valid_data_type
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Partially closes [#3833](https://github.com/ethyca/fides/issues/3833) and https://github.com/ethyca/fideslang/issues/139

### Description Of Changes

Adds new fields to System and Privacy Declaration to support new dictionary feature.  Deprecates related fields in System/PrivacyDeclaration/DataUse/Datasets.  The goal here is for all of these changes to be additive, and we can remove the deprecated fields at a later time.  

On the Fides side, we are migrating over data from the deprecated fields to their new locations, and hiding these fields in the UI, but leaving the original fields in place for now.

Context is here: [Confluence Dictionary Forms](https://ethyca.atlassian.net/wiki/spaces/PM/pages/2742648890/Dictionary+forms) and [Fideslang Updates](https://ethyca.atlassian.net/wiki/spaces/PM/pages/2740027499/Fideslang+updates)

### Code Changes

* [x] Deprecates the following fields: 
    - Dataset: `data_qualifier`, `joint_controller`, `retention`, and `third_country_transfers`
       - The idea is that these are more legal terms that don't belong on more of a data engineering construct. `data_qualifier` is being removed because we're not using.  The other three are being migrated/transformed to `System.joint_controller_info`, `PrivacyDeclaration.retention_period`, and `System.does_international_transfers`
   - Privacy Declaration: `data_qualifier`
       - Being removed as it's not being used.
    - System: `data_responsibility_title`, `joint_controller`, `third_country_transfers`, `data_protection_impact_assessment`. 
        -  These are being migrated/transformed to `System.responsibility`, `System.joint_controller_info`, `System.does_international_transfers`, `System.requires_data_protection_assessments`, `System.dpa_location`, and `System.dpa_progress`
    -  Data Use: `legal_basis`, `recipients`, `special_category`, `legitimate_interest`, `legitimate_interest_impact_assessment`.  
        - One is being dropped altogether, the other four are being moved/transformed to PrivacyDeclaration
* [x] Adds new fields to System and PrivacyDeclaration to support new Dictionary requirements

### Steps to Confirm

* [ ] See this in action by creating and updating systems on fides branch https://github.com/ethyca/fides/pull/3901, which is pinned to the latest commit here.  

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
