### PR TITLE
Convert "Version" types to "str" outside of validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,13 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unrelease](https://github.com/ethyca/fideslang/compare/2.0.0...main)
+## [Unrelease](https://github.com/ethyca/fideslang/compare/2.0.1...main)
+
+## [2.0.1](https://github.com/ethyca/fideslang/compare/2.0.0...2.0.1)
+
+### Changed
+
+- Fix validation around the new FidesVersion type [#151](https://github.com/ethyca/fideslang/pull/151)
 
 ## [2.0.0](https://github.com/ethyca/fideslang/compare/1.4.4...2.0.0)
 

--- a/scripts/export_default_taxonomy.py
+++ b/scripts/export_default_taxonomy.py
@@ -30,16 +30,6 @@ def export_yaml() -> None:
         print(f"> Writing YAML to {output_filename}")
         resources = [x.dict() for x in getattr(DEFAULT_TAXONOMY, resource_type)]
 
-        # Clean up specific data types
-
-        resources = [
-            {
-                key: str(value) if isinstance(value, Version) else value
-                for key, value in resource.items()
-            }
-            for resource in resources
-        ]
-
         write_manifest(
             output_filename,
             manifest=resources,

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -91,7 +91,7 @@ class DefaultModel(BaseModel):
     A model meant to be inherited by versioned parts of the Default Taxonomy.
     """
 
-    version_added: Optional[FidesVersion] = Field(
+    version_added: Optional[str] = Field(
         default=None,
         description="The version of Fideslang in which this label was added.",
     )

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -116,19 +116,29 @@ class DefaultModel(BaseModel):
 
     @validator("version_added")
     @classmethod
-    def validate_verion_added(cls, version_added: str, values: Dict) -> str:
+    def validate_verion_added(
+        cls, version_added: Optional[str], values: Dict
+    ) -> Optional[str]:
         """
         Validate that the `version_added` field is a proper FidesVersion
         """
+        if not version_added:
+            return None
+
         FidesVersion.validate(version_added)
         return version_added
 
     @validator("version_deprecated")
     @classmethod
-    def validate_version_deprecated(cls, version_deprecated: str, values: Dict) -> str:
+    def validate_version_deprecated(
+        cls, version_deprecated: Optional[str], values: Dict
+    ) -> Optional[str]:
         """
         Validate that the `version_deprecated` is a proper FidesVersion
         """
+        if not version_deprecated:
+            return None
+
         FidesVersion.validate(version_deprecated)
         return version_deprecated
 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -95,7 +95,7 @@ class DefaultModel(BaseModel):
         default=None,
         description="The version of Fideslang in which this label was added.",
     )
-    version_deprecated: Optional[FidesVersion] = Field(
+    version_deprecated: Optional[str] = Field(
         default=None,
         description="The version of Fideslang in which this label was deprecated.",
     )
@@ -113,6 +113,24 @@ class DefaultModel(BaseModel):
         deprecated_version_later_than_added_validator
     )
     _is_deprecated_if_replaced: classmethod = is_deprecated_if_replaced_validator
+
+    @validator("version_added")
+    @classmethod
+    def validate_verion_added(cls, version_added: str, values: Dict) -> str:
+        """
+        Validate that the `version_added` field is a proper FidesVersion
+        """
+        FidesVersion.validate(version_added)
+        return version_added
+
+    @validator("version_deprecated")
+    @classmethod
+    def validate_version_deprecated(cls, version_deprecated: str, values: Dict) -> str:
+        """
+        Validate that the `version_deprecated` is a proper FidesVersion
+        """
+        FidesVersion.validate(version_deprecated)
+        return version_deprecated
 
 
 class DataResponsibilityTitle(str, Enum):

--- a/src/fideslang/validation.py
+++ b/src/fideslang/validation.py
@@ -91,14 +91,18 @@ def no_self_reference(value: FidesKey, values: Dict) -> FidesKey:
 
 
 def deprecated_version_later_than_added(
-    version_deprecated: FidesVersion, values: Dict
-) -> FidesVersion:
+    version_deprecated: Optional[FidesVersion], values: Dict
+) -> Optional[FidesVersion]:
     """
     Check to make sure that the deprecated version is later than the added version.
 
     This will also catch errors where the deprecated version is defined but the added
     version is empty.
     """
+
+    if not version_deprecated:
+        return None
+
     if version_deprecated < values.get("version_added", Version("0")):
         raise FidesValidationError(
             "Deprecated version number can't be earlier than version added!"

--- a/tests/fideslang/test_default_taxonomy.py
+++ b/tests/fideslang/test_default_taxonomy.py
@@ -21,6 +21,10 @@ class TestDefaultTaxonomy:
         assert len(getattr(DEFAULT_TAXONOMY, data_type)) == expected_count
 
     @pytest.mark.parametrize("data_type", taxonomy_counts.keys())
+    def test_are_set_as_default(self, data_type: str) -> None:
+        assert all([x.is_default for x in getattr(DEFAULT_TAXONOMY, data_type)])
+
+    @pytest.mark.parametrize("data_type", taxonomy_counts.keys())
     def test_key_uniqueness(self, data_type: str) -> None:
         keys = [x.fides_key for x in getattr(DEFAULT_TAXONOMY, data_type)]
         duplicate_keys = {

--- a/tests/fideslang/test_validation.py
+++ b/tests/fideslang/test_validation.py
@@ -85,6 +85,36 @@ class TestVersioning:
             )
 
     @pytest.mark.parametrize("TaxonomyClass", DEFAULT_TAXONOMY_CLASSES)
+    def test_built_from_dict_with_empty_versions(self, TaxonomyClass) -> None:
+        """Item can't be deprecated in a version earlier than it was added."""
+        TaxonomyClass.parse_obj(
+            {
+                "organization_fides_key": 1,
+                "fides_key": "user",
+                "name": "Custom Test Data",
+                "description": "Custom Test Data Category",
+                "version_deprecated": None,
+                "version_added": None,
+                "replaced_by": None,
+                "is_default": False,
+            }
+        )
+
+    @pytest.mark.parametrize("TaxonomyClass", DEFAULT_TAXONOMY_CLASSES)
+    def test_built_with_empty_versions(self, TaxonomyClass) -> None:
+        """Item can't be deprecated in a version earlier than it was added."""
+        TaxonomyClass(
+            organization_fides_key=1,
+            fides_key="user",
+            name="Custom Test Data",
+            description="Custom Test Data Category",
+            version_deprecated=None,
+            version_added=None,
+            replaced_by=None,
+            is_default=False,
+        )
+
+    @pytest.mark.parametrize("TaxonomyClass", DEFAULT_TAXONOMY_CLASSES)
     def test_deprecated_not_added(self, TaxonomyClass):
         """Can't be deprecated without being added in an earlier version."""
         with pytest.raises(ValidationError):

--- a/tests/fideslang/test_validation.py
+++ b/tests/fideslang/test_validation.py
@@ -86,7 +86,7 @@ class TestVersioning:
 
     @pytest.mark.parametrize("TaxonomyClass", DEFAULT_TAXONOMY_CLASSES)
     def test_built_from_dict_with_empty_versions(self, TaxonomyClass) -> None:
-        """Item can't be deprecated in a version earlier than it was added."""
+        """Try building from a dictionary with explicit None values."""
         TaxonomyClass.parse_obj(
             {
                 "organization_fides_key": 1,
@@ -102,7 +102,7 @@ class TestVersioning:
 
     @pytest.mark.parametrize("TaxonomyClass", DEFAULT_TAXONOMY_CLASSES)
     def test_built_with_empty_versions(self, TaxonomyClass) -> None:
-        """Item can't be deprecated in a version earlier than it was added."""
+        """Try building directly with explicit None values."""
         TaxonomyClass(
             organization_fides_key=1,
             fides_key="user",


### PR DESCRIPTION
Closes #<issue>

### Description Of Changes

The clever (not so much apparently) `Version` type I created is causing issues with database insertion over in Fides ([PR}())

This uses the version during validation but otherwise treats it as a string. This will be released immediately as `Fideslang` version `2.0.1`

### Code Changes

* [x] add version validation while storing as strings
* [x] add new tests to validate empty values on instantiation

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [x] Issue Requirements are Met
* [x] Update `CHANGELOG.md`
