### PR TITLE
Fix docs site for fideslang 2.0.0

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -123,9 +123,13 @@ jobs:
   CSV-Checks:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Check CSV Files
         run: |
           echo "Check all data_files/*.csv for any empty lines..."
+          ls -l data_files/*.csv
           if grep -n -E '^$' data_files/*.csv; then
             echo "Error: Empty lines found"
           fi

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -120,11 +120,10 @@ jobs:
       - name: Run Tests
         run: nox -s "tests-${{ matrix.python_version }}(pyyaml_version='${{ matrix.pyyaml_version }}', pydantic_version='${{ matrix.pydantic_version }}')"
 
-
   CSV-Checks:
     runs-on: ubuntu-latest
     steps:
-      - name: Check CSV export for errors
+      - name: Check CSV Files
         run: |
           echo "Check all data_files/*.csv for any empty lines..."
           if grep -n -E '^$' data_files/*.csv; then

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -62,6 +62,14 @@ jobs:
       - name: Run Export
         run: python scripts/export_default_taxonomy.py
 
+      - name: Check CSV export for errors
+        run: |
+          echo "Check all data_files/*.csv for any empty lines..."
+          if grep -n -E '^$' data_files/*.csv; then
+            echo "Error: Empty lines found"
+          fi
+          echo "Success!"
+
   Static-Checks:
     continue-on-error: true
     strategy:

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -62,14 +62,6 @@ jobs:
       - name: Run Export
         run: python scripts/export_default_taxonomy.py
 
-      - name: Check CSV export for errors
-        run: |
-          echo "Check all data_files/*.csv for any empty lines..."
-          if grep -n -E '^$' data_files/*.csv; then
-            echo "Error: Empty lines found"
-          fi
-          echo "Success!"
-
   Static-Checks:
     continue-on-error: true
     strategy:
@@ -127,3 +119,15 @@ jobs:
 
       - name: Run Tests
         run: nox -s "tests-${{ matrix.python_version }}(pyyaml_version='${{ matrix.pyyaml_version }}', pydantic_version='${{ matrix.pydantic_version }}')"
+
+
+  CSV-Checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check CSV export for errors
+        run: |
+          echo "Check all data_files/*.csv for any empty lines..."
+          if grep -n -E '^$' data_files/*.csv; then
+            echo "Error: Empty lines found"
+          fi
+          echo "Success!"

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -131,6 +131,7 @@ jobs:
           echo "Check all data_files/*.csv for any empty lines..."
           ls -l data_files/*.csv
           if grep -n -E '^$' data_files/*.csv; then
-            echo "Error: Empty lines found"
+            echo "Error: empty lines found (see grep matches above)"
+            exit 1
           fi
           echo "Success!"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unrelease](https://github.com/ethyca/fideslang/compare/2.0.0...main)
+## [Unreleased](https://github.com/ethyca/fideslang/compare/2.0.0...main)
+
+### Fixed
+
+- Fix docs site for fideslang 2.0.0 [#154](https://github.com/ethyca/fideslang/pull/154)
 
 ## [2.0.0](https://github.com/ethyca/fideslang/compare/1.4.4...2.0.0)
 

--- a/data_files/data_categories.csv
+++ b/data_files/data_categories.csv
@@ -1,173 +1,87 @@
-fides_key,is_default,name,organization_fides_key,parent_key,tags,description
-
-data_category,,Data Category,,,,
-
-system,True,System Data,default_organization,data_category,,"Data unique to, and under control of the system."
-
-system.authentication,True,Authentication Data,default_organization,system,,Data used to manage access to the system.
-
-system.operations,True,Operations Data,default_organization,system,,Data used for system operations.
-
-user,True,User Data,default_organization,data_category,,"Data related to the user of the system, either provided directly or derived based on their usage."
-
-user.account,True,Account Information.,default_organization,user,,Account creation or registration information.
-
-user.authorization,True,Authorization Information.,default_organization,user,,Scope of permissions and access to a system.
-
-user.behavior,True,Observed Behavior,default_organization,user,,Behavioral data about the subject.
-
-user.biometric,True,Biometric Data,default_organization,user,,Encoded characteristics provided by a user.
-
-user.childrens,True,Children's Data,default_organization,user,,Data relating to children.
-
-user.contact,True,Contact Data,default_organization,user,,Contact data collected about a user.
-
-user.content,True,User Content,default_organization,user,,"Content related to, or created by the subject."
-
-user.demographic,True,Demographic Data,default_organization,user,,Demographic data about a user.
-
-user.location,True,Location Data,default_organization,user,,Records of the location of a user.
-
-user.device,True,Device Data,default_organization,user,,"Data related to a user's device, configuration and setting."
-
-user.payment,True,Payment Data,default_organization,user,,Payment data related to user.
-
-user.social,True,Social Data,default_organization,user,,Social activity and interaction data.
-
-user.unique_id,True,Unique ID,default_organization,user,,Unique identifier for a user assigned through system use.
-
-user.telemetry,True,Telemetry Data,default_organization,user,,User identifiable measurement data from system sensors and monitoring.
-
-user.user_sensor,True,User Sensor Data,default_organization,user,,Measurement data about a user's environment through system use.
-
-user.workplace,True,Workplace,default_organization,user,,Organization of employment.
-
-user.sensor,True,Sensor Data,default_organization,user,,Measurement data from sensors and monitoring systems.
-
-user.financial,True,Financial Data,default_organization,user,,Payment data and financial history.
-
-user.government_id,True,Government ID,default_organization,user,,State provided identification data.
-
-user.health_and_medical,True,Health and Medical Data,default_organization,user,,Health records or individual's personal medical information.
-
-user.name,True,Name,default_organization,user,,User's real name.
-
-user.criminal_history,True,Criminal History,default_organization,user,,Criminal records or information about the data subject.
-
-user.privacy_preferences,True,Privacy Preferences,default_organization,user,,Privacy preferences or settings set by the subject.
-
-user.job_title,True,Job Title,default_organization,user,,Professional data.
-
-user.account.settings,True,Account Settings,default_organization,user.account,,Account preferences and settings.
-
-user.account.username,True,Account Username,default_organization,user.account,,Username associated with account.
-
-user.authorization.credentials,True,Account password.,default_organization,user.authorization,,Authentication credentials to a system.
-
-user.authorization.biometric,True,Biometric Credentials,default_organization,user.authorization,,Credentials for system authentication.
-
-user.authorization.password,True,Password,default_organization,user.authorization,,Password for system authentication.
-
-user.behavior.browsing_history,True,Browsing History,default_organization,user.behavior,,Content browsing history of a user.
-
-user.behavior.media_consumption,True,Media Consumption,default_organization,user.behavior,,Content consumption history of the subject.
-
-user.behavior.purchase_history,True,Purchase History,default_organization,user.behavior,,Purchase history of the subject.
-
-user.behavior.search_history,True,Search History,default_organization,user.behavior,,Search history of the subject.
-
-user.biometric.fingerprint,True,Fingerprint,default_organization,user.biometric,,Fingerprint encoded data about a subject.
-
-user.biometric.retinal,True,Retina Scan,default_organization,user.biometric,,Retinal data about a subject.
-
-user.biometric.voice,True,Voice Recording,default_organization,user.biometric,,Voice encoded data about a subject.
-
-user.biometric.health,True,Biometric Health Data,default_organization,user.biometric,,Encoded characteristic collected about a user.
-
-user.contact.address,True,User Contact Address,default_organization,user.contact,,Contact address data collected about a user.
-
-user.contact.email,True,User Contact Email,default_organization,user.contact,,User's contact email address.
-
-user.contact.phone_number,True,User Contact Phone Number,default_organization,user.contact,,User's phone number.
-
-user.contact.url,True,User Website,default_organization,user.contact,,Subject's websites or links to social and personal profiles.
-
-user.contact.fax_number,True,Fax Number,default_organization,user.contact,,Data Subject's fax number.
-
-user.contact.organization,True,Organization,default_organization,user.contact,,Data Subject's Organization.
-
-user.contact.address.city,True,User Contact City,default_organization,user.contact.address,,User's city level address data.
-
-user.contact.address.country,True,User Contact Country,default_organization,user.contact.address,,User's country level address data.
-
-user.contact.address.postal_code,True,User Contact Postal Code,default_organization,user.contact.address,,User's postal code.
-
-user.contact.address.state,True,User Contact State,default_organization,user.contact.address,,User's state level address data.
-
-user.contact.address.street,True,User Contact Street,default_organization,user.contact.address,,User's street level address data.
-
-user.content.private,True,Private Content,default_organization,user.content,,"Private content related to, or created by the subject, not publicly available."
-
-user.content.public,True,Public Content,default_organization,user.content,,"Publicly shared Content related to, or created by the subject."
-
-user.content.self_image,True,User Image,default_organization,user.content,,Photograph or image in which subject is whole or partially recognized.
-
-user.demographic.age_range,True,Age Range,default_organization,user.demographic,,Non specific age or age-range of data subject.
-
-user.demographic.date_of_birth,True,Birth Date,default_organization,user.demographic,,Date of birth of data subject.
-
-user.demographic.gender,True,Gender,default_organization,user.demographic,,Gender of data subject.
-
-user.demographic.language,True,Language,default_organization,user.demographic,,Spoken or written language of subject.
-
-user.demographic.marital_status,True,Marital Status,default_organization,user.demographic,,Marital status of data subject.
-
-user.demographic.political_opinion,True,Political Opinion,default_organization,user.demographic,,Political opinion or belief of data subject.
-
-user.demographic.profile,True,User Profile Data,default_organization,user.demographic,,Profile or preference information about the data subject.
-
-user.demographic.race_ethnicity,True,Race,default_organization,user.demographic,,Race or ethnicity of data subject.
-
-user.demographic.religious_belief,True,Religion,default_organization,user.demographic,,Religion or religious beliefs of the data subject.
-
-user.demographic.sexual_orientation,True,Sexual Orientation,default_organization,user.demographic,,Sexual orientation of data subject.
-
-user.device.cookie,True,Device Cookie,default_organization,user.device,,"Data related to a subject, stored within a cookie."
-
-user.device.cookie_id,True,Cookie ID,default_organization,user.device,,Cookie unique identification number.
-
-user.device.device_id,True,Device ID,default_organization,user.device,,Device unique identification number.
-
-user.device.ip_address,True,IP Address,default_organization,user.device,,Unique identifier related to device connection.
-
-user.financial.bank_account,True,Bank Account Information,default_organization,user.financial,,Bank account information belonging to the subject.
-
-user.financial.credit_card,True,Credit Card Information,default_organization,user.financial,,Credit card information belonging to the subject.
-
-user.government_id.birth_certificate,True,Birth Certificate,default_organization,user.government_id,,State issued certificate of birth.
-
-user.government_id.drivers_license_number,True,Driver's License Number,default_organization,user.government_id,,State issued driving identification number.
-
-user.government_id.immigration,True,Immigration ID,default_organization,user.government_id,,State issued immigration or residency data.
-
-user.government_id.national_identification_number,True,National Identification Number,default_organization,user.government_id,,State issued personal identification number.
-
-user.government_id.passport_number,True,Passport Number,default_organization,user.government_id,,State issued passport data.
-
-user.government_id.vehicle_registration,True,Vehicle Registration,default_organization,user.government_id,,State issued license plate or vehicle registration data.
-
-user.health_and_medical.genetic,True,User's Genetic Data,default_organization,user.health_and_medical,,Data about the genetic makeup provided by the subject.
-
-user.health_and_medical.insurance_beneficiary_id,True,Medical Insurance ID,default_organization,user.health_and_medical,,Health insurance beneficiary number of the subject.
-
-user.health_and_medical.record_id,True,Medical Record ID,default_organization,user.health_and_medical,,Medical record identifiers belonging to a subject.
-
-user.location.imprecise,True,Imprecise Subject Location,default_organization,user.location,,Imprecise location derived from sensors (more than 500M).
-
-user.location.precise,True,Precise Subject Location,default_organization,user.location,,Precise location derived from sensors (less than 500M).
-
-user.name.first,True,First Name,default_organization,user.name,,Subject's first name.
-
-user.name.last,True,Last Name,default_organization,user.name,,"Subject's last, or family, name."
-
-user.unique_id.pseudonymous,True,Pseudonymous User ID,default_organization,user.unique_id,,"A pseudonymous, or probabilistic identifier generated from other subject or device data belonging to the subject."
+fides_key,is_default,name,organization_fides_key,parent_key,replaced_by,tags,version_added,version_deprecated,description
+data_category,,Data Category,,,,,,,
+system,True,System Data,default_organization,data_category,,,2.0.0,,"Data unique to, and under control of the system."
+system.authentication,True,Authentication Data,default_organization,system,,,2.0.0,,Data used to manage access to the system.
+system.operations,True,Operations Data,default_organization,system,,,2.0.0,,Data used for system operations.
+user,True,User Data,default_organization,data_category,,,2.0.0,,"Data related to the user of the system, either provided directly or derived based on their usage."
+user.account,True,Account Information.,default_organization,user,,,2.0.0,,Account creation or registration information.
+user.authorization,True,Authorization Information.,default_organization,user,,,2.0.0,,Scope of permissions and access to a system.
+user.behavior,True,Observed Behavior,default_organization,user,,,2.0.0,,Behavioral data about the subject.
+user.biometric,True,Biometric Data,default_organization,user,,,2.0.0,,Encoded characteristics provided by a user.
+user.childrens,True,Children's Data,default_organization,user,,,2.0.0,,Data relating to children.
+user.contact,True,Contact Data,default_organization,user,,,2.0.0,,Contact data collected about a user.
+user.content,True,User Content,default_organization,user,,,2.0.0,,"Content related to, or created by the subject."
+user.demographic,True,Demographic Data,default_organization,user,,,2.0.0,,Demographic data about a user.
+user.location,True,Location Data,default_organization,user,,,2.0.0,,Records of the location of a user.
+user.device,True,Device Data,default_organization,user,,,2.0.0,,"Data related to a user's device, configuration and setting."
+user.payment,True,Payment Data,default_organization,user,,,2.0.0,,Payment data related to user.
+user.social,True,Social Data,default_organization,user,,,2.0.0,,Social activity and interaction data.
+user.unique_id,True,Unique ID,default_organization,user,,,2.0.0,,Unique identifier for a user assigned through system use.
+user.telemetry,True,Telemetry Data,default_organization,user,,,2.0.0,,User identifiable measurement data from system sensors and monitoring.
+user.user_sensor,True,User Sensor Data,default_organization,user,,,2.0.0,,Measurement data about a user's environment through system use.
+user.workplace,True,Workplace,default_organization,user,,,2.0.0,,Organization of employment.
+user.sensor,True,Sensor Data,default_organization,user,,,2.0.0,,Measurement data from sensors and monitoring systems.
+user.financial,True,Financial Data,default_organization,user,,,2.0.0,,Payment data and financial history.
+user.government_id,True,Government ID,default_organization,user,,,2.0.0,,State provided identification data.
+user.health_and_medical,True,Health and Medical Data,default_organization,user,,,2.0.0,,Health records or individual's personal medical information.
+user.name,True,Name,default_organization,user,,,2.0.0,,User's real name.
+user.criminal_history,True,Criminal History,default_organization,user,,,2.0.0,,Criminal records or information about the data subject.
+user.privacy_preferences,True,Privacy Preferences,default_organization,user,,,2.0.0,,Privacy preferences or settings set by the subject.
+user.job_title,True,Job Title,default_organization,user,,,2.0.0,,Professional data.
+user.account.settings,True,Account Settings,default_organization,user.account,,,2.0.0,,Account preferences and settings.
+user.account.username,True,Account Username,default_organization,user.account,,,2.0.0,,Username associated with account.
+user.authorization.credentials,True,Account password.,default_organization,user.authorization,,,2.0.0,,Authentication credentials to a system.
+user.authorization.biometric,True,Biometric Credentials,default_organization,user.authorization,,,2.0.0,,Credentials for system authentication.
+user.authorization.password,True,Password,default_organization,user.authorization,,,2.0.0,,Password for system authentication.
+user.behavior.browsing_history,True,Browsing History,default_organization,user.behavior,,,2.0.0,,Content browsing history of a user.
+user.behavior.media_consumption,True,Media Consumption,default_organization,user.behavior,,,2.0.0,,Content consumption history of the subject.
+user.behavior.purchase_history,True,Purchase History,default_organization,user.behavior,,,2.0.0,,Purchase history of the subject.
+user.behavior.search_history,True,Search History,default_organization,user.behavior,,,2.0.0,,Search history of the subject.
+user.biometric.fingerprint,True,Fingerprint,default_organization,user.biometric,,,2.0.0,,Fingerprint encoded data about a subject.
+user.biometric.retinal,True,Retina Scan,default_organization,user.biometric,,,2.0.0,,Retinal data about a subject.
+user.biometric.voice,True,Voice Recording,default_organization,user.biometric,,,2.0.0,,Voice encoded data about a subject.
+user.biometric.health,True,Biometric Health Data,default_organization,user.biometric,,,2.0.0,,Encoded characteristic collected about a user.
+user.contact.address,True,User Contact Address,default_organization,user.contact,,,2.0.0,,Contact address data collected about a user.
+user.contact.email,True,User Contact Email,default_organization,user.contact,,,2.0.0,,User's contact email address.
+user.contact.phone_number,True,User Contact Phone Number,default_organization,user.contact,,,2.0.0,,User's phone number.
+user.contact.url,True,User Website,default_organization,user.contact,,,2.0.0,,Subject's websites or links to social and personal profiles.
+user.contact.fax_number,True,Fax Number,default_organization,user.contact,,,2.0.0,,Data Subject's fax number.
+user.contact.organization,True,Organization,default_organization,user.contact,,,2.0.0,,Data Subject's Organization.
+user.contact.address.city,True,User Contact City,default_organization,user.contact.address,,,2.0.0,,User's city level address data.
+user.contact.address.country,True,User Contact Country,default_organization,user.contact.address,,,2.0.0,,User's country level address data.
+user.contact.address.postal_code,True,User Contact Postal Code,default_organization,user.contact.address,,,2.0.0,,User's postal code.
+user.contact.address.state,True,User Contact State,default_organization,user.contact.address,,,2.0.0,,User's state level address data.
+user.contact.address.street,True,User Contact Street,default_organization,user.contact.address,,,2.0.0,,User's street level address data.
+user.content.private,True,Private Content,default_organization,user.content,,,2.0.0,,"Private content related to, or created by the subject, not publicly available."
+user.content.public,True,Public Content,default_organization,user.content,,,2.0.0,,"Publicly shared Content related to, or created by the subject."
+user.content.self_image,True,User Image,default_organization,user.content,,,2.0.0,,Photograph or image in which subject is whole or partially recognized.
+user.demographic.age_range,True,Age Range,default_organization,user.demographic,,,2.0.0,,Non specific age or age-range of data subject.
+user.demographic.date_of_birth,True,Birth Date,default_organization,user.demographic,,,2.0.0,,Date of birth of data subject.
+user.demographic.gender,True,Gender,default_organization,user.demographic,,,2.0.0,,Gender of data subject.
+user.demographic.language,True,Language,default_organization,user.demographic,,,2.0.0,,Spoken or written language of subject.
+user.demographic.marital_status,True,Marital Status,default_organization,user.demographic,,,2.0.0,,Marital status of data subject.
+user.demographic.political_opinion,True,Political Opinion,default_organization,user.demographic,,,2.0.0,,Political opinion or belief of data subject.
+user.demographic.profile,True,User Profile Data,default_organization,user.demographic,,,2.0.0,,Profile or preference information about the data subject.
+user.demographic.race_ethnicity,True,Race,default_organization,user.demographic,,,2.0.0,,Race or ethnicity of data subject.
+user.demographic.religious_belief,True,Religion,default_organization,user.demographic,,,2.0.0,,Religion or religious beliefs of the data subject.
+user.demographic.sexual_orientation,True,Sexual Orientation,default_organization,user.demographic,,,2.0.0,,Sexual orientation of data subject.
+user.device.cookie,True,Device Cookie,default_organization,user.device,,,2.0.0,,"Data related to a subject, stored within a cookie."
+user.device.cookie_id,True,Cookie ID,default_organization,user.device,,,2.0.0,,Cookie unique identification number.
+user.device.device_id,True,Device ID,default_organization,user.device,,,2.0.0,,Device unique identification number.
+user.device.ip_address,True,IP Address,default_organization,user.device,,,2.0.0,,Unique identifier related to device connection.
+user.financial.bank_account,True,Bank Account Information,default_organization,user.financial,,,2.0.0,,Bank account information belonging to the subject.
+user.financial.credit_card,True,Credit Card Information,default_organization,user.financial,,,2.0.0,,Credit card information belonging to the subject.
+user.government_id.birth_certificate,True,Birth Certificate,default_organization,user.government_id,,,2.0.0,,State issued certificate of birth.
+user.government_id.drivers_license_number,True,Driver's License Number,default_organization,user.government_id,,,2.0.0,,State issued driving identification number.
+user.government_id.immigration,True,Immigration ID,default_organization,user.government_id,,,2.0.0,,State issued immigration or residency data.
+user.government_id.national_identification_number,True,National Identification Number,default_organization,user.government_id,,,2.0.0,,State issued personal identification number.
+user.government_id.passport_number,True,Passport Number,default_organization,user.government_id,,,2.0.0,,State issued passport data.
+user.government_id.vehicle_registration,True,Vehicle Registration,default_organization,user.government_id,,,2.0.0,,State issued license plate or vehicle registration data.
+user.health_and_medical.genetic,True,User's Genetic Data,default_organization,user.health_and_medical,,,2.0.0,,Data about the genetic makeup provided by the subject.
+user.health_and_medical.insurance_beneficiary_id,True,Medical Insurance ID,default_organization,user.health_and_medical,,,2.0.0,,Health insurance beneficiary number of the subject.
+user.health_and_medical.record_id,True,Medical Record ID,default_organization,user.health_and_medical,,,2.0.0,,Medical record identifiers belonging to a subject.
+user.location.imprecise,True,Imprecise Subject Location,default_organization,user.location,,,2.0.0,,Imprecise location derived from sensors (more than 500M).
+user.location.precise,True,Precise Subject Location,default_organization,user.location,,,2.0.0,,Precise location derived from sensors (less than 500M).
+user.name.first,True,First Name,default_organization,user.name,,,2.0.0,,Subject's first name.
+user.name.last,True,Last Name,default_organization,user.name,,,2.0.0,,"Subject's last, or family, name."
+user.unique_id.pseudonymous,True,Pseudonymous User ID,default_organization,user.unique_id,,,2.0.0,,"A pseudonymous, or probabilistic identifier generated from other subject or device data belonging to the subject."

--- a/data_files/data_categories.json
+++ b/data_files/data_categories.json
@@ -49,31 +49,16 @@
             "parent_key": null
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.account",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Account Information.",
             "description": "Account creation or registration information.",
-            "parent_key": "user",
-            "is_default": true
-        },
-        {
-            "fides_key": "user.authorization",
-            "organization_fides_key": "default_organization",
-            "tags": null,
-            "name": "Authorization Information.",
-            "description": "Scope of permissions and access to a system.",
-            "parent_key": "user",
-            "is_default": true
-        },
-        {
-            "fides_key": "user.behavior",
-            "organization_fides_key": "default_organization",
-            "tags": null,
-            "name": "Observed Behavior",
-            "description": "Behavioral data about the subject.",
-            "parent_key": "user",
-            "is_default": true
+            "parent_key": "user"
         },
         {
             "version_added": "2.0.0",
@@ -109,136 +94,181 @@
             "tags": null,
             "name": "Biometric Data",
             "description": "Encoded characteristics provided by a user.",
-            "parent_key": "user",
-            "is_default": true
+            "parent_key": "user"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.childrens",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Children's Data",
             "description": "Data relating to children.",
-            "parent_key": "user",
-            "is_default": true
+            "parent_key": "user"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.contact",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Contact Data",
             "description": "Contact data collected about a user.",
-            "parent_key": "user",
-            "is_default": true
+            "parent_key": "user"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.content",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "User Content",
             "description": "Content related to, or created by the subject.",
-            "parent_key": "user",
-            "is_default": true
+            "parent_key": "user"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.demographic",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Demographic Data",
             "description": "Demographic data about a user.",
-            "parent_key": "user",
-            "is_default": true
+            "parent_key": "user"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.location",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Location Data",
             "description": "Records of the location of a user.",
-            "parent_key": "user",
-            "is_default": true
+            "parent_key": "user"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.device",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Device Data",
             "description": "Data related to a user's device, configuration and setting.",
-            "parent_key": "user",
-            "is_default": true
+            "parent_key": "user"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.payment",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Payment Data",
             "description": "Payment data related to user.",
-            "parent_key": "user",
-            "is_default": true
+            "parent_key": "user"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.social",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Social Data",
             "description": "Social activity and interaction data.",
-            "parent_key": "user",
-            "is_default": true
+            "parent_key": "user"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.unique_id",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Unique ID",
             "description": "Unique identifier for a user assigned through system use.",
-            "parent_key": "user",
-            "is_default": true
+            "parent_key": "user"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.telemetry",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Telemetry Data",
             "description": "User identifiable measurement data from system sensors and monitoring.",
-            "parent_key": "user",
-            "is_default": true
+            "parent_key": "user"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.user_sensor",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "User Sensor Data",
             "description": "Measurement data about a user's environment through system use.",
-            "parent_key": "user",
-            "is_default": true
+            "parent_key": "user"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.workplace",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Workplace",
             "description": "Organization of employment.",
-            "parent_key": "user",
-            "is_default": true
+            "parent_key": "user"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.sensor",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Sensor Data",
             "description": "Measurement data from sensors and monitoring systems.",
-            "parent_key": "user",
-            "is_default": true
+            "parent_key": "user"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.financial",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Financial Data",
             "description": "Payment data and financial history.",
-            "parent_key": "user",
-            "is_default": true
+            "parent_key": "user"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.government_id",
             "organization_fides_key": "default_organization",
             "tags": null,
@@ -256,10 +286,13 @@
             "tags": null,
             "name": "Health and Medical Data",
             "description": "Health records or individual's personal medical information.",
-            "parent_key": "user",
-            "is_default": true
+            "parent_key": "user"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.name",
             "organization_fides_key": "default_organization",
             "tags": null,
@@ -268,150 +301,202 @@
             "parent_key": "user"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.criminal_history",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Criminal History",
             "description": "Criminal records or information about the data subject.",
-            "parent_key": "user",
-            "is_default": true
+            "parent_key": "user"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.privacy_preferences",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Privacy Preferences",
             "description": "Privacy preferences or settings set by the subject.",
-            "parent_key": "user",
-            "is_default": true
+            "parent_key": "user"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.job_title",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Job Title",
             "description": "Professional data.",
-            "parent_key": "user",
-            "is_default": true
+            "parent_key": "user"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.account.settings",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Account Settings",
             "description": "Account preferences and settings.",
-            "parent_key": "user.account",
-            "is_default": true
+            "parent_key": "user.account"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.account.username",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Account Username",
             "description": "Username associated with account.",
-            "parent_key": "user.account",
-            "is_default": true
+            "parent_key": "user.account"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.authorization.credentials",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Account password.",
             "description": "Authentication credentials to a system.",
-            "parent_key": "user.authorization",
-            "is_default": true
+            "parent_key": "user.authorization"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.authorization.biometric",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Biometric Credentials",
             "description": "Credentials for system authentication.",
-            "parent_key": "user.authorization",
-            "is_default": true
+            "parent_key": "user.authorization"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.authorization.password",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Password",
             "description": "Password for system authentication.",
-            "parent_key": "user.authorization",
-            "is_default": true
+            "parent_key": "user.authorization"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.behavior.browsing_history",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Browsing History",
             "description": "Content browsing history of a user.",
-            "parent_key": "user.behavior",
-            "is_default": true
+            "parent_key": "user.behavior"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.behavior.media_consumption",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Media Consumption",
             "description": "Content consumption history of the subject.",
-            "parent_key": "user.behavior",
-            "is_default": true
+            "parent_key": "user.behavior"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.behavior.purchase_history",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Purchase History",
             "description": "Purchase history of the subject.",
-            "parent_key": "user.behavior",
-            "is_default": true
+            "parent_key": "user.behavior"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.behavior.search_history",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Search History",
             "description": "Search history of the subject.",
-            "parent_key": "user.behavior",
-            "is_default": true
+            "parent_key": "user.behavior"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.biometric.fingerprint",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Fingerprint",
             "description": "Fingerprint encoded data about a subject.",
-            "parent_key": "user.biometric",
-            "is_default": true
+            "parent_key": "user.biometric"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.biometric.retinal",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Retina Scan",
             "description": "Retinal data about a subject.",
-            "parent_key": "user.biometric",
-            "is_default": true
+            "parent_key": "user.biometric"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.biometric.voice",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Voice Recording",
             "description": "Voice encoded data about a subject.",
-            "parent_key": "user.biometric",
-            "is_default": true
+            "parent_key": "user.biometric"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.biometric.health",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Biometric Health Data",
             "description": "Encoded characteristic collected about a user.",
-            "parent_key": "user.biometric",
-            "is_default": true
+            "parent_key": "user.biometric"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.contact.address",
             "organization_fides_key": "default_organization",
             "tags": null,
@@ -444,33 +529,46 @@
             "parent_key": "user.contact"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.contact.url",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "User Website",
             "description": "Subject's websites or links to social and personal profiles.",
-            "parent_key": "user.contact",
-            "is_default": true
+            "parent_key": "user.contact"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.contact.fax_number",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Fax Number",
             "description": "Data Subject's fax number.",
-            "parent_key": "user.contact",
-            "is_default": true
+            "parent_key": "user.contact"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.contact.organization",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Organization",
             "description": "Data Subject's Organization.",
-            "parent_key": "user.contact",
-            "is_default": true
+            "parent_key": "user.contact"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.contact.address.city",
             "organization_fides_key": "default_organization",
             "tags": null,
@@ -527,130 +625,28 @@
             "parent_key": "user.contact.address"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.content.private",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Private Content",
             "description": "Private content related to, or created by the subject, not publicly available.",
-            "parent_key": "user.content",
-            "is_default": true
+            "parent_key": "user.content"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.content.public",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Public Content",
             "description": "Publicly shared Content related to, or created by the subject.",
-            "parent_key": "user.content",
-            "is_default": true
-        },
-        {
-            "fides_key": "user.content.self_image",
-            "organization_fides_key": "default_organization",
-            "tags": null,
-            "name": "User Image",
-            "description": "Photograph or image in which subject is whole or partially recognized.",
-            "parent_key": "user.content",
-            "is_default": true
-        },
-        {
-            "fides_key": "user.demographic.age_range",
-            "organization_fides_key": "default_organization",
-            "tags": null,
-            "name": "Age Range",
-            "description": "Non specific age or age-range of data subject.",
-            "parent_key": "user.demographic",
-            "is_default": true
-        },
-        {
-            "fides_key": "user.demographic.date_of_birth",
-            "organization_fides_key": "default_organization",
-            "tags": null,
-            "name": "Birth Date",
-            "description": "Date of birth of data subject.",
-            "parent_key": "user.demographic",
-            "is_default": true
-        },
-        {
-            "fides_key": "user.demographic.gender",
-            "organization_fides_key": "default_organization",
-            "tags": null,
-            "name": "Gender",
-            "description": "Gender of data subject.",
-            "parent_key": "user.demographic",
-            "is_default": true
-        },
-        {
-            "fides_key": "user.demographic.language",
-            "organization_fides_key": "default_organization",
-            "tags": null,
-            "name": "Language",
-            "description": "Spoken or written language of subject.",
-            "parent_key": "user.demographic",
-            "is_default": true
-        },
-        {
-            "fides_key": "user.demographic.marital_status",
-            "organization_fides_key": "default_organization",
-            "tags": null,
-            "name": "Marital Status",
-            "description": "Marital status of data subject.",
-            "parent_key": "user.demographic",
-            "is_default": true
-        },
-        {
-            "fides_key": "user.demographic.political_opinion",
-            "organization_fides_key": "default_organization",
-            "tags": null,
-            "name": "Political Opinion",
-            "description": "Political opinion or belief of data subject.",
-            "parent_key": "user.demographic",
-            "is_default": true
-        },
-        {
-            "fides_key": "user.demographic.profile",
-            "organization_fides_key": "default_organization",
-            "tags": null,
-            "name": "User Profile Data",
-            "description": "Profile or preference information about the data subject.",
-            "parent_key": "user.demographic",
-            "is_default": true
-        },
-        {
-            "fides_key": "user.demographic.race_ethnicity",
-            "organization_fides_key": "default_organization",
-            "tags": null,
-            "name": "Race",
-            "description": "Race or ethnicity of data subject.",
-            "parent_key": "user.demographic",
-            "is_default": true
-        },
-        {
-            "fides_key": "user.demographic.religious_belief",
-            "organization_fides_key": "default_organization",
-            "tags": null,
-            "name": "Religion",
-            "description": "Religion or religious beliefs of the data subject.",
-            "parent_key": "user.demographic",
-            "is_default": true
-        },
-        {
-            "fides_key": "user.demographic.sexual_orientation",
-            "organization_fides_key": "default_organization",
-            "tags": null,
-            "name": "Sexual Orientation",
-            "description": "Sexual orientation of data subject.",
-            "parent_key": "user.demographic",
-            "is_default": true
-        },
-        {
-            "fides_key": "user.device.cookie",
-            "organization_fides_key": "default_organization",
-            "tags": null,
-            "name": "Device Cookie",
-            "description": "Data related to a subject, stored within a cookie.",
-            "parent_key": "user.device",
-            "is_default": true
+            "parent_key": "user.content"
         },
         {
             "version_added": "2.0.0",
@@ -833,33 +829,46 @@
             "parent_key": "user.device"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.financial.bank_account",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Bank Account Information",
             "description": "Bank account information belonging to the subject.",
-            "parent_key": "user.financial",
-            "is_default": true
+            "parent_key": "user.financial"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.financial.credit_card",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Credit Card Information",
             "description": "Credit card information belonging to the subject.",
-            "parent_key": "user.financial",
-            "is_default": true
+            "parent_key": "user.financial"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.government_id.birth_certificate",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Birth Certificate",
             "description": "State issued certificate of birth.",
-            "parent_key": "user.government_id",
-            "is_default": true
+            "parent_key": "user.government_id"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.government_id.drivers_license_number",
             "organization_fides_key": "default_organization",
             "tags": null,
@@ -868,15 +877,22 @@
             "parent_key": "user.government_id"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.government_id.immigration",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Immigration ID",
             "description": "State issued immigration or residency data.",
-            "parent_key": "user.government_id",
-            "is_default": true
+            "parent_key": "user.government_id"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.government_id.national_identification_number",
             "organization_fides_key": "default_organization",
             "tags": null,
@@ -897,85 +913,112 @@
             "parent_key": "user.government_id"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.government_id.vehicle_registration",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Vehicle Registration",
             "description": "State issued license plate or vehicle registration data.",
-            "parent_key": "user.government_id",
-            "is_default": true
+            "parent_key": "user.government_id"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.health_and_medical.genetic",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "User's Genetic Data",
             "description": "Data about the genetic makeup provided by the subject.",
-            "parent_key": "user.health_and_medical",
-            "is_default": true
+            "parent_key": "user.health_and_medical"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.health_and_medical.insurance_beneficiary_id",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Medical Insurance ID",
             "description": "Health insurance beneficiary number of the subject.",
-            "parent_key": "user.health_and_medical",
-            "is_default": true
+            "parent_key": "user.health_and_medical"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.health_and_medical.record_id",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Medical Record ID",
             "description": "Medical record identifiers belonging to a subject.",
-            "parent_key": "user.health_and_medical",
-            "is_default": true
+            "parent_key": "user.health_and_medical"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.location.imprecise",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Imprecise Subject Location",
             "description": "Imprecise location derived from sensors (more than 500M).",
-            "parent_key": "user.location",
-            "is_default": true
+            "parent_key": "user.location"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.location.precise",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Precise Subject Location",
             "description": "Precise location derived from sensors (less than 500M).",
-            "parent_key": "user.location",
-            "is_default": true
+            "parent_key": "user.location"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.name.first",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "First Name",
             "description": "Subject's first name.",
-            "parent_key": "user.name",
-            "is_default": true
+            "parent_key": "user.name"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.name.last",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Last Name",
             "description": "Subject's last, or family, name.",
-            "parent_key": "user.name",
-            "is_default": true
+            "parent_key": "user.name"
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "user.unique_id.pseudonymous",
             "organization_fides_key": "default_organization",
             "tags": null,
             "name": "Pseudonymous User ID",
             "description": "A pseudonymous, or probabilistic identifier generated from other subject or device data belonging to the subject.",
-            "parent_key": "user.unique_id",
-            "is_default": true
+            "parent_key": "user.unique_id"
         }
     ]
 }

--- a/data_files/data_categories.yml
+++ b/data_files/data_categories.yml
@@ -44,25 +44,11 @@ data_category:
   version_deprecated: null
   replaced_by: null
   is_default: true
-- fides_key: user.account
+  fides_key: user.account
   organization_fides_key: default_organization
   tags: null
   name: Account Information.
   description: Account creation or registration information.
-  parent_key: user
-  is_default: true
-- fides_key: user.authorization
-  organization_fides_key: default_organization
-  tags: null
-  name: Authorization Information.
-  description: Scope of permissions and access to a system.
-  parent_key: user
-  is_default: true
-- fides_key: user.behavior
-  organization_fides_key: default_organization
-  tags: null
-  name: Observed Behavior
-  description: Behavioral data about the subject.
   parent_key: user
 - version_added: 2.0.0
   version_deprecated: null
@@ -98,98 +84,137 @@ data_category:
   version_deprecated: null
   replaced_by: null
   is_default: true
-- fides_key: user.childrens
+  fides_key: user.childrens
   organization_fides_key: default_organization
   tags: null
   name: Children's Data
   description: Data relating to children.
   parent_key: user
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.contact
+  fides_key: user.contact
   organization_fides_key: default_organization
   tags: null
   name: Contact Data
   description: Contact data collected about a user.
   parent_key: user
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.content
+  fides_key: user.content
   organization_fides_key: default_organization
   tags: null
   name: User Content
   description: Content related to, or created by the subject.
   parent_key: user
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.demographic
+  fides_key: user.demographic
   organization_fides_key: default_organization
   tags: null
   name: Demographic Data
   description: Demographic data about a user.
   parent_key: user
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.location
+  fides_key: user.location
   organization_fides_key: default_organization
   tags: null
   name: Location Data
   description: Records of the location of a user.
   parent_key: user
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.device
+  fides_key: user.device
   organization_fides_key: default_organization
   tags: null
   name: Device Data
   description: Data related to a user's device, configuration and setting.
   parent_key: user
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.payment
+  fides_key: user.payment
   organization_fides_key: default_organization
   tags: null
   name: Payment Data
   description: Payment data related to user.
   parent_key: user
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.social
+  fides_key: user.social
   organization_fides_key: default_organization
   tags: null
   name: Social Data
   description: Social activity and interaction data.
   parent_key: user
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.unique_id
+  fides_key: user.unique_id
   organization_fides_key: default_organization
   tags: null
   name: Unique ID
   description: Unique identifier for a user assigned through system use.
   parent_key: user
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.telemetry
+  fides_key: user.telemetry
   organization_fides_key: default_organization
   tags: null
   name: Telemetry Data
   description: User identifiable measurement data from system sensors and monitoring.
   parent_key: user
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.user_sensor
+  fides_key: user.user_sensor
   organization_fides_key: default_organization
   tags: null
   name: User Sensor Data
   description: Measurement data about a user's environment through system use.
   parent_key: user
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.workplace
+  fides_key: user.workplace
   organization_fides_key: default_organization
   tags: null
   name: Workplace
   description: Organization of employment.
   parent_key: user
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.sensor
+  fides_key: user.sensor
   organization_fides_key: default_organization
   tags: null
   name: Sensor Data
   description: Measurement data from sensors and monitoring systems.
   parent_key: user
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.financial
+  fides_key: user.financial
   organization_fides_key: default_organization
   tags: null
   name: Financial Data
@@ -199,7 +224,7 @@ data_category:
   version_deprecated: null
   replaced_by: null
   is_default: true
-- fides_key: user.government_id
+  fides_key: user.government_id
   organization_fides_key: default_organization
   tags: null
   name: Government ID
@@ -219,7 +244,7 @@ data_category:
   version_deprecated: null
   replaced_by: null
   is_default: true
-- fides_key: user.name
+  fides_key: user.name
   organization_fides_key: default_organization
   tags: null
   name: Name
@@ -229,7 +254,7 @@ data_category:
   version_deprecated: null
   replaced_by: null
   is_default: true
-- fides_key: user.criminal_history
+  fides_key: user.criminal_history
   organization_fides_key: default_organization
   tags: null
   name: Criminal History
@@ -239,112 +264,157 @@ data_category:
   version_deprecated: null
   replaced_by: null
   is_default: true
-- fides_key: user.privacy_preferences
+  fides_key: user.privacy_preferences
   organization_fides_key: default_organization
   tags: null
   name: Privacy Preferences
   description: Privacy preferences or settings set by the subject.
   parent_key: user
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.job_title
+  fides_key: user.job_title
   organization_fides_key: default_organization
   tags: null
   name: Job Title
   description: Professional data.
   parent_key: user
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.account.settings
+  fides_key: user.account.settings
   organization_fides_key: default_organization
   tags: null
   name: Account Settings
   description: Account preferences and settings.
   parent_key: user.account
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.account.username
+  fides_key: user.account.username
   organization_fides_key: default_organization
   tags: null
   name: Account Username
   description: Username associated with account.
   parent_key: user.account
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.authorization.credentials
+  fides_key: user.authorization.credentials
   organization_fides_key: default_organization
   tags: null
   name: Account password.
   description: Authentication credentials to a system.
   parent_key: user.authorization
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.authorization.biometric
+  fides_key: user.authorization.biometric
   organization_fides_key: default_organization
   tags: null
   name: Biometric Credentials
   description: Credentials for system authentication.
   parent_key: user.authorization
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.authorization.password
+  fides_key: user.authorization.password
   organization_fides_key: default_organization
   tags: null
   name: Password
   description: Password for system authentication.
   parent_key: user.authorization
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.behavior.browsing_history
+  fides_key: user.behavior.browsing_history
   organization_fides_key: default_organization
   tags: null
   name: Browsing History
   description: Content browsing history of a user.
   parent_key: user.behavior
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.behavior.media_consumption
+  fides_key: user.behavior.media_consumption
   organization_fides_key: default_organization
   tags: null
   name: Media Consumption
   description: Content consumption history of the subject.
   parent_key: user.behavior
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.behavior.purchase_history
+  fides_key: user.behavior.purchase_history
   organization_fides_key: default_organization
   tags: null
   name: Purchase History
   description: Purchase history of the subject.
   parent_key: user.behavior
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.behavior.search_history
+  fides_key: user.behavior.search_history
   organization_fides_key: default_organization
   tags: null
   name: Search History
   description: Search history of the subject.
   parent_key: user.behavior
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.biometric.fingerprint
+  fides_key: user.biometric.fingerprint
   organization_fides_key: default_organization
   tags: null
   name: Fingerprint
   description: Fingerprint encoded data about a subject.
   parent_key: user.biometric
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.biometric.retinal
+  fides_key: user.biometric.retinal
   organization_fides_key: default_organization
   tags: null
   name: Retina Scan
   description: Retinal data about a subject.
   parent_key: user.biometric
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.biometric.voice
+  fides_key: user.biometric.voice
   organization_fides_key: default_organization
   tags: null
   name: Voice Recording
   description: Voice encoded data about a subject.
   parent_key: user.biometric
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.biometric.health
+  fides_key: user.biometric.health
   organization_fides_key: default_organization
   tags: null
   name: Biometric Health Data
   description: Encoded characteristic collected about a user.
   parent_key: user.biometric
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.contact.address
+  fides_key: user.contact.address
   organization_fides_key: default_organization
   tags: null
   name: User Contact Address
@@ -374,28 +444,37 @@ data_category:
   version_deprecated: null
   replaced_by: null
   is_default: true
-- fides_key: user.contact.url
+  fides_key: user.contact.url
   organization_fides_key: default_organization
   tags: null
   name: User Website
   description: Subject's websites or links to social and personal profiles.
   parent_key: user.contact
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.contact.fax_number
+  fides_key: user.contact.fax_number
   organization_fides_key: default_organization
   tags: null
   name: Fax Number
   description: Data Subject's fax number.
   parent_key: user.contact
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.contact.organization
+  fides_key: user.contact.organization
   organization_fides_key: default_organization
   tags: null
   name: Organization
   description: Data Subject's Organization.
   parent_key: user.contact
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.contact.address.city
+  fides_key: user.contact.address.city
   organization_fides_key: default_organization
   tags: null
   name: User Contact City
@@ -445,104 +524,26 @@ data_category:
   version_deprecated: null
   replaced_by: null
   is_default: true
-- fides_key: user.content.private
+  fides_key: user.content.private
   organization_fides_key: default_organization
   tags: null
   name: Private Content
   description: Private content related to, or created by the subject, not publicly
     available.
   parent_key: user.content
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.content.public
+  fides_key: user.content.public
   organization_fides_key: default_organization
   tags: null
   name: Public Content
   description: Publicly shared Content related to, or created by the subject.
   parent_key: user.content
-  is_default: true
-- fides_key: user.content.self_image
-  organization_fides_key: default_organization
-  tags: null
-  name: User Image
-  description: Photograph or image in which subject is whole or partially recognized.
-  parent_key: user.content
-  is_default: true
-- fides_key: user.demographic.age_range
-  organization_fides_key: default_organization
-  tags: null
-  name: Age Range
-  description: Non specific age or age-range of data subject.
-  parent_key: user.demographic
-  is_default: true
-- fides_key: user.demographic.date_of_birth
-  organization_fides_key: default_organization
-  tags: null
-  name: Birth Date
-  description: Date of birth of data subject.
-  parent_key: user.demographic
-  is_default: true
-- fides_key: user.demographic.gender
-  organization_fides_key: default_organization
-  tags: null
-  name: Gender
-  description: Gender of data subject.
-  parent_key: user.demographic
-  is_default: true
-- fides_key: user.demographic.language
-  organization_fides_key: default_organization
-  tags: null
-  name: Language
-  description: Spoken or written language of subject.
-  parent_key: user.demographic
-  is_default: true
-- fides_key: user.demographic.marital_status
-  organization_fides_key: default_organization
-  tags: null
-  name: Marital Status
-  description: Marital status of data subject.
-  parent_key: user.demographic
-  is_default: true
-- fides_key: user.demographic.political_opinion
-  organization_fides_key: default_organization
-  tags: null
-  name: Political Opinion
-  description: Political opinion or belief of data subject.
-  parent_key: user.demographic
-  is_default: true
-- fides_key: user.demographic.profile
-  organization_fides_key: default_organization
-  tags: null
-  name: User Profile Data
-  description: Profile or preference information about the data subject.
-  parent_key: user.demographic
-  is_default: true
-- fides_key: user.demographic.race_ethnicity
-  organization_fides_key: default_organization
-  tags: null
-  name: Race
-  description: Race or ethnicity of data subject.
-  parent_key: user.demographic
-  is_default: true
-- fides_key: user.demographic.religious_belief
-  organization_fides_key: default_organization
-  tags: null
-  name: Religion
-  description: Religion or religious beliefs of the data subject.
-  parent_key: user.demographic
-  is_default: true
-- fides_key: user.demographic.sexual_orientation
-  organization_fides_key: default_organization
-  tags: null
-  name: Sexual Orientation
-  description: Sexual orientation of data subject.
-  parent_key: user.demographic
-  is_default: true
-- fides_key: user.device.cookie
-  organization_fides_key: default_organization
-  tags: null
-  name: Device Cookie
-  description: Data related to a subject, stored within a cookie.
-  parent_key: user.device
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
   fides_key: user.content.self_image
   organization_fides_key: default_organization
@@ -694,7 +695,7 @@ data_category:
   version_deprecated: null
   replaced_by: null
   is_default: true
-- fides_key: user.financial.bank_account
+  fides_key: user.financial.bank_account
   organization_fides_key: default_organization
   tags: null
   name: Bank Account Information
@@ -704,21 +705,27 @@ data_category:
   version_deprecated: null
   replaced_by: null
   is_default: true
-- fides_key: user.financial.credit_card
+  fides_key: user.financial.credit_card
   organization_fides_key: default_organization
   tags: null
   name: Credit Card Information
   description: Credit card information belonging to the subject.
   parent_key: user.financial
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.government_id.birth_certificate
+  fides_key: user.government_id.birth_certificate
   organization_fides_key: default_organization
   tags: null
   name: Birth Certificate
   description: State issued certificate of birth.
   parent_key: user.government_id
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.government_id.drivers_license_number
+  fides_key: user.government_id.drivers_license_number
   organization_fides_key: default_organization
   tags: null
   name: Driver's License Number
@@ -728,14 +735,17 @@ data_category:
   version_deprecated: null
   replaced_by: null
   is_default: true
-- fides_key: user.government_id.immigration
+  fides_key: user.government_id.immigration
   organization_fides_key: default_organization
   tags: null
   name: Immigration ID
   description: State issued immigration or residency data.
   parent_key: user.government_id
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: user.government_id.national_identification_number
+  fides_key: user.government_id.national_identification_number
   organization_fides_key: default_organization
   tags: null
   name: National Identification Number
@@ -755,69 +765,15 @@ data_category:
   version_deprecated: null
   replaced_by: null
   is_default: true
-- fides_key: user.government_id.vehicle_registration
+  fides_key: user.government_id.vehicle_registration
   organization_fides_key: default_organization
   tags: null
   name: Vehicle Registration
   description: State issued license plate or vehicle registration data.
   parent_key: user.government_id
-  is_default: true
-- fides_key: user.health_and_medical.genetic
-  organization_fides_key: default_organization
-  tags: null
-  name: User's Genetic Data
-  description: Data about the genetic makeup provided by the subject.
-  parent_key: user.health_and_medical
-  is_default: true
-- fides_key: user.health_and_medical.insurance_beneficiary_id
-  organization_fides_key: default_organization
-  tags: null
-  name: Medical Insurance ID
-  description: Health insurance beneficiary number of the subject.
-  parent_key: user.health_and_medical
-  is_default: true
-- fides_key: user.health_and_medical.record_id
-  organization_fides_key: default_organization
-  tags: null
-  name: Medical Record ID
-  description: Medical record identifiers belonging to a subject.
-  parent_key: user.health_and_medical
-  is_default: true
-- fides_key: user.location.imprecise
-  organization_fides_key: default_organization
-  tags: null
-  name: Imprecise Subject Location
-  description: Imprecise location derived from sensors (more than 500M).
-  parent_key: user.location
-  is_default: true
-- fides_key: user.location.precise
-  organization_fides_key: default_organization
-  tags: null
-  name: Precise Subject Location
-  description: Precise location derived from sensors (less than 500M).
-  parent_key: user.location
-  is_default: true
-- fides_key: user.name.first
-  organization_fides_key: default_organization
-  tags: null
-  name: First Name
-  description: Subject's first name.
-  parent_key: user.name
-  is_default: true
-- fides_key: user.name.last
-  organization_fides_key: default_organization
-  tags: null
-  name: Last Name
-  description: Subject's last, or family, name.
-  parent_key: user.name
-  is_default: true
-- fides_key: user.unique_id.pseudonymous
-  organization_fides_key: default_organization
-  tags: null
-  name: Pseudonymous User ID
-  description: A pseudonymous, or probabilistic identifier generated from other subject
-    or device data belonging to the subject.
-  parent_key: user.unique_id
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
   fides_key: user.health_and_medical.genetic
   organization_fides_key: default_organization

--- a/data_files/data_qualifiers.csv
+++ b/data_files/data_qualifiers.csv
@@ -1,13 +1,7 @@
-fides_key,is_default,name,organization_fides_key,parent_key,tags,description
-
-data_qualifier,,Data Qualifier,,,,
-
-aggregated,True,Aggregated Data,default_organization,data_qualifier,,Statistical data that does not contain individually identifying information but includes information about groups of individuals that renders individual identification impossible.
-
-aggregated.anonymized,True,Anonymized Data,default_organization,aggregated,,Data where all attributes have been sufficiently altered that the individaul cannot be reidentified by this data or in combination with other datasets.
-
-aggregated.anonymized.unlinked_pseudonymized,True,Unlinked Pseudonymized Data,default_organization,aggregated.anonymized,,"Data for which all identifiers have been substituted with unrelated values and linkages broken such that it may not be reversed, even by the party that performed the pseudonymization."
-
-aggregated.anonymized.unlinked_pseudonymized.pseudonymized,True,Pseudonymized Data,default_organization,aggregated.anonymized.unlinked_pseudonymized,,"Data for which all identifiers have been substituted with unrelated values, rendering the individual unidentifiable and cannot be reasonably reversed other than by the party that performed the pseudonymization."
-
-aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified,True,Identified Data,default_organization,aggregated.anonymized.unlinked_pseudonymized.pseudonymized,,Data that directly identifies an individual.
+fides_key,is_default,name,organization_fides_key,parent_key,replaced_by,tags,version_added,version_deprecated,description
+data_qualifier,,Data Qualifier,,,,,,,
+aggregated,True,Aggregated Data,default_organization,data_qualifier,,,2.0.0,,Statistical data that does not contain individually identifying information but includes information about groups of individuals that renders individual identification impossible.
+aggregated.anonymized,True,Anonymized Data,default_organization,aggregated,,,2.0.0,,Data where all attributes have been sufficiently altered that the individaul cannot be reidentified by this data or in combination with other datasets.
+aggregated.anonymized.unlinked_pseudonymized,True,Unlinked Pseudonymized Data,default_organization,aggregated.anonymized,,,2.0.0,,"Data for which all identifiers have been substituted with unrelated values and linkages broken such that it may not be reversed, even by the party that performed the pseudonymization."
+aggregated.anonymized.unlinked_pseudonymized.pseudonymized,True,Pseudonymized Data,default_organization,aggregated.anonymized.unlinked_pseudonymized,,,2.0.0,,"Data for which all identifiers have been substituted with unrelated values, rendering the individual unidentifiable and cannot be reasonably reversed other than by the party that performed the pseudonymization."
+aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified,True,Identified Data,default_organization,aggregated.anonymized.unlinked_pseudonymized.pseudonymized,,,2.0.0,,Data that directly identifies an individual.

--- a/data_files/data_subjects.csv
+++ b/data_files/data_subjects.csv
@@ -1,33 +1,17 @@
-automated_decisions_or_profiling,fides_key,is_default,name,organization_fides_key,rights,tags,parent_key,description
-
-,data_subject,,Data Subject,,,,,
-
-,anonymous_user,True,Anonymous User,default_organization,,,data_subject,An individual that is unidentifiable to the systems. Note - This should only be applied to truly anonymous users where there is no risk of re-identification
-
-,citizen_voter,True,Citizen Voter,default_organization,,,data_subject,An individual registered to voter with a state or authority.
-
-,commuter,True,Commuter,default_organization,,,data_subject,An individual that is traveling or transiting in the context of location tracking.
-
-,consultant,True,Consultant,default_organization,,,data_subject,An individual employed in a consultative/temporary capacity by the organization.
-
-,customer,True,Customer,default_organization,,,data_subject,An individual or other organization that purchases goods or services from the organization.
-
-,employee,True,Employee,default_organization,,,data_subject,An individual employed by the organization.
-
-,job_applicant,True,Job Applicant,default_organization,,,data_subject,An individual applying for employment to the organization.
-
-,next_of_kin,True,Next of Kin,default_organization,,,data_subject,A relative of any other individual subject where such a relationship is known.
-
-,passenger,True,Passenger,default_organization,,,data_subject,An individual traveling on some means of provided transport.
-
-,patient,True,Patient,default_organization,,,data_subject,An individual identified for the purposes of any medical care.
-
-,prospect,True,Prospect,default_organization,,,data_subject,An individual or organization to whom an organization is selling goods or services.
-
-,shareholder,True,Shareholder,default_organization,,,data_subject,An individual or organization that holds equity in the organization.
-
-,supplier_vendor,True,Supplier/Vendor,default_organization,,,data_subject,An individual or organization that provides services or goods to the organization.
-
-,trainee,True,Trainee,default_organization,,,data_subject,An individual undergoing training by the organization.
-
-,visitor,True,Visitor,default_organization,,,data_subject,An individual visiting a location.
+automated_decisions_or_profiling,fides_key,is_default,name,organization_fides_key,replaced_by,rights,tags,version_added,version_deprecated,parent_key,description
+,data_subject,,Data Subject,,,,,,,,
+,anonymous_user,True,Anonymous User,default_organization,,,,2.0.0,,data_subject,An individual that is unidentifiable to the systems. Note - This should only be applied to truly anonymous users where there is no risk of re-identification
+,citizen_voter,True,Citizen Voter,default_organization,,,,2.0.0,,data_subject,An individual registered to voter with a state or authority.
+,commuter,True,Commuter,default_organization,,,,2.0.0,,data_subject,An individual that is traveling or transiting in the context of location tracking.
+,consultant,True,Consultant,default_organization,,,,2.0.0,,data_subject,An individual employed in a consultative/temporary capacity by the organization.
+,customer,True,Customer,default_organization,,,,2.0.0,,data_subject,An individual or other organization that purchases goods or services from the organization.
+,employee,True,Employee,default_organization,,,,2.0.0,,data_subject,An individual employed by the organization.
+,job_applicant,True,Job Applicant,default_organization,,,,2.0.0,,data_subject,An individual applying for employment to the organization.
+,next_of_kin,True,Next of Kin,default_organization,,,,2.0.0,,data_subject,A relative of any other individual subject where such a relationship is known.
+,passenger,True,Passenger,default_organization,,,,2.0.0,,data_subject,An individual traveling on some means of provided transport.
+,patient,True,Patient,default_organization,,,,2.0.0,,data_subject,An individual identified for the purposes of any medical care.
+,prospect,True,Prospect,default_organization,,,,2.0.0,,data_subject,An individual or organization to whom an organization is selling goods or services.
+,shareholder,True,Shareholder,default_organization,,,,2.0.0,,data_subject,An individual or organization that holds equity in the organization.
+,supplier_vendor,True,Supplier/Vendor,default_organization,,,,2.0.0,,data_subject,An individual or organization that provides services or goods to the organization.
+,trainee,True,Trainee,default_organization,,,,2.0.0,,data_subject,An individual undergoing training by the organization.
+,visitor,True,Visitor,default_organization,,,,2.0.0,,data_subject,An individual visiting a location.

--- a/data_files/data_uses.csv
+++ b/data_files/data_uses.csv
@@ -1,107 +1,54 @@
-fides_key,is_default,legal_basis,legitimate_interest,legitimate_interest_impact_assessment,name,organization_fides_key,parent_key,recipients,special_category,tags,description
-
-data_use,,,,,Data Use,,,,,,
-
-analytics,True,,,,Analytics,default_organization,data_use,,,,"Provides analytics for activities such as system and advertising performance reporting, insights and fraud detection."
-
-analytics.reporting,True,,,,Analytics for Reporting,default_organization,analytics,,,,Provides analytics for general reporting such as system and advertising performance.
-
-analytics.reporting.ad_performance,True,,,,Analytics for Advertising Performance,default_organization,analytics.reporting,,,,Provides analytics for reporting of advertising performance.
-
-analytics.reporting.content_performance,True,,,,Analytics for Content Performance,default_organization,analytics.reporting,,,,Analytics for reporting on content performance.
-
-analytics.reporting.campaign_insights,True,,,,Analytics for Insights,default_organization,analytics.reporting,,,,Provides analytics for reporting of campaign insights related to advertising and promotion activities.
-
-analytics.reporting.system,True,,,,Analytics for System Activity,default_organization,analytics.reporting,,,,Provides analytics for reporting on system activity.
-
-analytics.reporting.system.performance,True,,,,Analytics for System Performance,default_organization,analytics.reporting.system,,,,Provides analytics for reporting on system performance.
-
-collect,True,,,,Collect,default_organization,data_use,,,,Collects or stores data in order to use it for another purpose which has not yet been expressly defined.
-
-employment,True,,,,Employment,default_organization,data_use,,,,Processes data for the purpose of recruitment or employment and human resources (HR) related activities.
-
-employment.recruitment,True,,,,Employment Recruitment,default_organization,employment,,,,Processes data of prospective employees for the purpose of recruitment.
-
-essential,True,,,,Essential,default_organization,data_use,,,,"Operates the service or product, including legal obligations, support and basic system operations."
-
-essential.fraud_detection,True,,,,Essential Fraud Detection,default_organization,essential,,,,"Detects possible fraud or misuse of the product, service, application or system."
-
-essential.legal_obligation,True,,,,Essential Legal Obligation,default_organization,essential,,,,Provides service to meet a legal or compliance obligation such as consent management.
-
-essential.service,True,,,,Essential for Service,default_organization,essential,,,,"Provides the essential product, service, application or system, without which the product/service would not be possible."
-
-essential.service.authentication,True,,,,Essential Service Authentication,default_organization,essential.service,,,,"Authenticate users to the product, service, application or system."
-
-essential.service.notifications,True,,,,Essential Service Notifications,default_organization,essential.service,,,,"Sends notifications about the product, service, application or system."
-
-essential.service.operations,True,,,,Essential for Operations,default_organization,essential.service,,,,"Essential to ensure the operation of the product, service, application or system."
-
-essential.service.payment_processing,True,,,,Essential for Payment Processing,default_organization,essential.service,,,,"Essential to processes payments for the product, service, application or system."
-
-essential.service.security,True,,,,Essential for Security,default_organization,essential.service,,,,"Essential to provide security for the product, service, application or system"
-
-essential.service.upgrades,True,,,,Essential for Service Upgrades,default_organization,essential.service,,,,Provides timely system upgrade information options.
-
-essential.service.notifications.email,True,,,,Essential Email Service Notifications,default_organization,essential.service.notifications,,,,"Sends email notifications about the product, service, application or system."
-
-essential.service.notifications.sms,True,,,,Essential SMS Service Notifications,default_organization,essential.service.notifications,,,,"Sends SMS notifications about the product, service, application or system."
-
-essential.service.operations.support,True,,,,Essential for Operations Support,default_organization,essential.service.operations,,,,"Provides support for the product, service, application or system."
-
-essential.service.operations.improve,True,,,,Essential for Support Improvement,default_organization,essential.service.operations,,,,"Essential to optimize and improve support for the product, service, application or system."
-
-finance,True,,,,Finance,default_organization,data_use,,,,Enables finance and accounting activities such as audits and tax reporting.
-
-functional,True,,,,Functional,default_organization,data_use,,,,"Used for specific, necessary, and legitimate purposes"
-
-functional.storage,True,,,,Local Data Storage,default_organization,functional,,,,"Stores or accesses information from the device as needed when using a product, service, application, or system"
-
-functional.service,True,,,,Service,default_organization,functional,,,,"Functions relating to provided services, products, applications or systems."
-
-functional.service.improve,True,,,,Improve Service,default_organization,functional.service,,,,"Improves the specific product, service, application or system."
-
-marketing,True,,,,Marketing,default_organization,data_use,,,,"Enables marketing, promotion, advertising and sales activities for the product, service, application or system."
-
-marketing.advertising,True,,,,"Advertising, Marketing or Promotion",default_organization,marketing,,,,"Advertises or promotes the product, service, application or system and associated services."
-
-marketing.communications,True,,,,Marketing Communications,default_organization,marketing,,,,"Uses combined channels to message and market to a customer, user or prospect."
-
-marketing.advertising.first_party,True,,,,First Party Advertising,default_organization,marketing.advertising,,,,Serves advertisements based on first party data collected or derived about the user.
-
-marketing.advertising.frequency_capping,True,,,,Frequency Capping,default_organization,marketing.advertising,,,,Restricts the number of times a specific advertisement is shown to an individual.
-
-marketing.advertising.negative_targeting,True,,,,Negative Targeting,default_organization,marketing.advertising,,,,Enforces rules used to ensure a certain audience or group is not targeted by advertising.
-
-marketing.advertising.profiling,True,,,,Profiling for Advertising,default_organization,marketing.advertising,,,,Creates audience profiles for the purpose of targeted advertising
-
-marketing.advertising.serving,True,,,,Essential for Serving Ads,default_organization,marketing.advertising,,,,Essential to the delivery of advertising and content.
-
-marketing.advertising.third_party,True,,,,Third Party Advertising,default_organization,marketing.advertising,,,,Serves advertisements based on data within the system or joined with data provided by 3rd parties.
-
-marketing.advertising.first_party.contextual,True,,,,First Party Contextual Advertising,default_organization,marketing.advertising.first_party,,,,Serves advertisements based on current content being viewed by the user of the system or service.
-
-marketing.advertising.first_party.targeted,True,,,,First Party Personalized Advertising,default_organization,marketing.advertising.first_party,,,,Targets advertisements based on data collected or derived about the user from use of the system.
-
-marketing.advertising.third_party.targeted,True,,,,Third Party Targeted Advertising,default_organization,marketing.advertising.third_party,,,,Targets advertisements based on data within the system or joined with data provided by 3rd parties.
-
-marketing.communications.email,True,,,,Marketing Email Communications,default_organization,marketing.communications,,,,Sends email marketing communications.
-
-marketing.communications.sms,True,,,,Marketing SMS Communications,default_organization,marketing.communications,,,,Sends SMS marketing communications.
-
-operations,True,,,,Operations,default_organization,data_use,,,,Supports business processes necessary to the organization's operation.
-
-personalize,True,,,,Personalize,default_organization,data_use,,,,"Personalizes the product, service, application or system."
-
-personalize.content,True,,,,Content Personalization,default_organization,personalize,,,,"Personalizes the content of the product, service, application or system."
-
-personalize.profiling,True,,,,Personalized Profiling,default_organization,personalize,,,,Creates profiles for the purpose of serving content.
-
-personalize.system,True,,,,System Personalization,default_organization,personalize,,,,Personalizes the system.
-
-sales,True,,,,Sales,default_organization,data_use,,,,Supports sales activities such as communications and outreach.
-
-third_party_sharing,True,,,,Third Party Sharing,default_organization,data_use,,,,Transfers data to third parties outside of the system or service's scope.
-
-third_party_sharing.legal_obligation,True,,,,Sharing for Legal Obligation,default_organization,third_party_sharing,,,,"Shares data for legal obligations, including contracts, applicable laws or regulations."
-
-train_ai_system,True,,,,Train AI System,default_organization,data_use,,,,Trains an AI system or data model for machine learning.
+fides_key,is_default,legal_basis,legitimate_interest,legitimate_interest_impact_assessment,name,organization_fides_key,parent_key,recipients,replaced_by,special_category,tags,version_added,version_deprecated,description
+data_use,,,,,Data Use,,,,,,,,,
+analytics,True,,,,Analytics,default_organization,data_use,,,,,2.0.0,,"Provides analytics for activities such as system and advertising performance reporting, insights and fraud detection."
+analytics.reporting,True,,,,Analytics for Reporting,default_organization,analytics,,,,,2.0.0,,Provides analytics for general reporting such as system and advertising performance.
+analytics.reporting.ad_performance,True,,,,Analytics for Advertising Performance,default_organization,analytics.reporting,,,,,2.0.0,,Provides analytics for reporting of advertising performance.
+analytics.reporting.content_performance,True,,,,Analytics for Content Performance,default_organization,analytics.reporting,,,,,2.0.0,,Analytics for reporting on content performance.
+analytics.reporting.campaign_insights,True,,,,Analytics for Insights,default_organization,analytics.reporting,,,,,2.0.0,,Provides analytics for reporting of campaign insights related to advertising and promotion activities.
+analytics.reporting.system,True,,,,Analytics for System Activity,default_organization,analytics.reporting,,,,,2.0.0,,Provides analytics for reporting on system activity.
+analytics.reporting.system.performance,True,,,,Analytics for System Performance,default_organization,analytics.reporting.system,,,,,2.0.0,,Provides analytics for reporting on system performance.
+collect,True,,,,Collect,default_organization,data_use,,,,,2.0.0,,Collects or stores data in order to use it for another purpose which has not yet been expressly defined.
+employment,True,,,,Employment,default_organization,data_use,,,,,2.0.0,,Processes data for the purpose of recruitment or employment and human resources (HR) related activities.
+employment.recruitment,True,,,,Employment Recruitment,default_organization,employment,,,,,2.0.0,,Processes data of prospective employees for the purpose of recruitment.
+essential,True,,,,Essential,default_organization,data_use,,,,,2.0.0,,"Operates the service or product, including legal obligations, support and basic system operations."
+essential.fraud_detection,True,,,,Essential Fraud Detection,default_organization,essential,,,,,2.0.0,,"Detects possible fraud or misuse of the product, service, application or system."
+essential.legal_obligation,True,,,,Essential Legal Obligation,default_organization,essential,,,,,2.0.0,,Provides service to meet a legal or compliance obligation such as consent management.
+essential.service,True,,,,Essential for Service,default_organization,essential,,,,,2.0.0,,"Provides the essential product, service, application or system, without which the product/service would not be possible."
+essential.service.authentication,True,,,,Essential Service Authentication,default_organization,essential.service,,,,,2.0.0,,"Authenticate users to the product, service, application or system."
+essential.service.notifications,True,,,,Essential Service Notifications,default_organization,essential.service,,,,,2.0.0,,"Sends notifications about the product, service, application or system."
+essential.service.operations,True,,,,Essential for Operations,default_organization,essential.service,,,,,2.0.0,,"Essential to ensure the operation of the product, service, application or system."
+essential.service.payment_processing,True,,,,Essential for Payment Processing,default_organization,essential.service,,,,,2.0.0,,"Essential to processes payments for the product, service, application or system."
+essential.service.security,True,,,,Essential for Security,default_organization,essential.service,,,,,2.0.0,,"Essential to provide security for the product, service, application or system"
+essential.service.upgrades,True,,,,Essential for Service Upgrades,default_organization,essential.service,,,,,2.0.0,,Provides timely system upgrade information options.
+essential.service.notifications.email,True,,,,Essential Email Service Notifications,default_organization,essential.service.notifications,,,,,2.0.0,,"Sends email notifications about the product, service, application or system."
+essential.service.notifications.sms,True,,,,Essential SMS Service Notifications,default_organization,essential.service.notifications,,,,,2.0.0,,"Sends SMS notifications about the product, service, application or system."
+essential.service.operations.support,True,,,,Essential for Operations Support,default_organization,essential.service.operations,,,,,2.0.0,,"Provides support for the product, service, application or system."
+essential.service.operations.improve,True,,,,Essential for Support Improvement,default_organization,essential.service.operations,,,,,2.0.0,,"Essential to optimize and improve support for the product, service, application or system."
+finance,True,,,,Finance,default_organization,data_use,,,,,2.0.0,,Enables finance and accounting activities such as audits and tax reporting.
+functional,True,,,,Functional,default_organization,data_use,,,,,2.0.0,,"Used for specific, necessary, and legitimate purposes"
+functional.storage,True,,,,Local Data Storage,default_organization,functional,,,,,2.0.0,,"Stores or accesses information from the device as needed when using a product, service, application, or system"
+functional.service,True,,,,Service,default_organization,functional,,,,,2.0.0,,"Functions relating to provided services, products, applications or systems."
+functional.service.improve,True,,,,Improve Service,default_organization,functional.service,,,,,2.0.0,,"Improves the specific product, service, application or system."
+marketing,True,,,,Marketing,default_organization,data_use,,,,,2.0.0,,"Enables marketing, promotion, advertising and sales activities for the product, service, application or system."
+marketing.advertising,True,,,,"Advertising, Marketing or Promotion",default_organization,marketing,,,,,2.0.0,,"Advertises or promotes the product, service, application or system and associated services."
+marketing.communications,True,,,,Marketing Communications,default_organization,marketing,,,,,2.0.0,,"Uses combined channels to message and market to a customer, user or prospect."
+marketing.advertising.first_party,True,,,,First Party Advertising,default_organization,marketing.advertising,,,,,2.0.0,,Serves advertisements based on first party data collected or derived about the user.
+marketing.advertising.frequency_capping,True,,,,Frequency Capping,default_organization,marketing.advertising,,,,,2.0.0,,Restricts the number of times a specific advertisement is shown to an individual.
+marketing.advertising.negative_targeting,True,,,,Negative Targeting,default_organization,marketing.advertising,,,,,2.0.0,,Enforces rules used to ensure a certain audience or group is not targeted by advertising.
+marketing.advertising.profiling,True,,,,Profiling for Advertising,default_organization,marketing.advertising,,,,,2.0.0,,Creates audience profiles for the purpose of targeted advertising
+marketing.advertising.serving,True,,,,Essential for Serving Ads,default_organization,marketing.advertising,,,,,2.0.0,,Essential to the delivery of advertising and content.
+marketing.advertising.third_party,True,,,,Third Party Advertising,default_organization,marketing.advertising,,,,,2.0.0,,Serves advertisements based on data within the system or joined with data provided by 3rd parties.
+marketing.advertising.first_party.contextual,True,,,,First Party Contextual Advertising,default_organization,marketing.advertising.first_party,,,,,2.0.0,,Serves advertisements based on current content being viewed by the user of the system or service.
+marketing.advertising.first_party.targeted,True,,,,First Party Personalized Advertising,default_organization,marketing.advertising.first_party,,,,,2.0.0,,Targets advertisements based on data collected or derived about the user from use of the system.
+marketing.advertising.third_party.targeted,True,,,,Third Party Targeted Advertising,default_organization,marketing.advertising.third_party,,,,,2.0.0,,Targets advertisements based on data within the system or joined with data provided by 3rd parties.
+marketing.communications.email,True,,,,Marketing Email Communications,default_organization,marketing.communications,,,,,2.0.0,,Sends email marketing communications.
+marketing.communications.sms,True,,,,Marketing SMS Communications,default_organization,marketing.communications,,,,,2.0.0,,Sends SMS marketing communications.
+operations,True,,,,Operations,default_organization,data_use,,,,,2.0.0,,Supports business processes necessary to the organization's operation.
+personalize,True,,,,Personalize,default_organization,data_use,,,,,2.0.0,,"Personalizes the product, service, application or system."
+personalize.content,True,,,,Content Personalization,default_organization,personalize,,,,,2.0.0,,"Personalizes the content of the product, service, application or system."
+personalize.profiling,True,,,,Personalized Profiling,default_organization,personalize,,,,,2.0.0,,Creates profiles for the purpose of serving content.
+personalize.system,True,,,,System Personalization,default_organization,personalize,,,,,2.0.0,,Personalizes the system.
+sales,True,,,,Sales,default_organization,data_use,,,,,2.0.0,,Supports sales activities such as communications and outreach.
+third_party_sharing,True,,,,Third Party Sharing,default_organization,data_use,,,,,2.0.0,,Transfers data to third parties outside of the system or service's scope.
+third_party_sharing.legal_obligation,True,,,,Sharing for Legal Obligation,default_organization,third_party_sharing,,,,,2.0.0,,"Shares data for legal obligations, including contracts, applicable laws or regulations."
+train_ai_system,True,,,,Train AI System,default_organization,data_use,,,,,2.0.0,,Trains an AI system or data model for machine learning.

--- a/data_files/data_uses.json
+++ b/data_files/data_uses.json
@@ -15,8 +15,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -33,8 +32,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -51,22 +49,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
-        },
-        {
-            "fides_key": "analytics.reporting.content_performance",
-            "organization_fides_key": "default_organization",
-            "tags": null,
-            "name": "Analytics for Content Performance",
-            "description": "Analytics for reporting on content performance.",
-            "parent_key": "analytics.reporting",
-            "legal_basis": null,
-            "special_category": null,
-            "recipients": null,
-            "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -100,8 +83,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -118,8 +100,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -136,8 +117,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -154,8 +134,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -172,8 +151,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -190,8 +168,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -208,8 +185,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -226,8 +202,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -244,8 +219,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -262,8 +236,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -280,8 +253,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -298,8 +270,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -316,8 +287,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -334,22 +304,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
-        },
-        {
-            "fides_key": "essential.service.security",
-            "organization_fides_key": "default_organization",
-            "tags": null,
-            "name": "Essential for Security",
-            "description": "Essential to provide security for the product, service, application or system",
-            "parent_key": "essential.service",
-            "legal_basis": null,
-            "special_category": null,
-            "recipients": null,
-            "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -383,8 +338,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -401,8 +355,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -419,8 +372,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -437,10 +389,13 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "essential.service.operations.improve",
             "organization_fides_key": "default_organization",
             "tags": null,
@@ -451,8 +406,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -469,10 +423,13 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "functional",
             "organization_fides_key": "default_organization",
             "tags": null,
@@ -483,10 +440,13 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "functional.storage",
             "organization_fides_key": "default_organization",
             "tags": null,
@@ -497,10 +457,13 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "functional.service",
             "organization_fides_key": "default_organization",
             "tags": null,
@@ -511,22 +474,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
-        },
-        {
-            "fides_key": "functional.service.improve",
-            "organization_fides_key": "default_organization",
-            "tags": null,
-            "name": "Improve Service",
-            "description": "Improves the specific product, service, application or system.",
-            "parent_key": "functional.service",
-            "legal_basis": null,
-            "special_category": null,
-            "recipients": null,
-            "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -560,8 +508,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -578,8 +525,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -596,8 +542,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -614,8 +559,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -632,8 +576,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -650,36 +593,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
-        },
-        {
-            "fides_key": "marketing.advertising.profiling",
-            "organization_fides_key": "default_organization",
-            "tags": null,
-            "name": "Profiling for Advertising",
-            "description": "Creates audience profiles for the purpose of targeted advertising",
-            "parent_key": "marketing.advertising",
-            "legal_basis": null,
-            "special_category": null,
-            "recipients": null,
-            "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
-        },
-        {
-            "fides_key": "marketing.advertising.serving",
-            "organization_fides_key": "default_organization",
-            "tags": null,
-            "name": "Essential for Serving Ads",
-            "description": "Essential to the delivery of advertising and content.",
-            "parent_key": "marketing.advertising",
-            "legal_basis": null,
-            "special_category": null,
-            "recipients": null,
-            "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -730,8 +644,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -748,8 +661,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -766,8 +678,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -784,8 +695,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -802,8 +712,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -820,8 +729,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -838,8 +746,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -856,8 +763,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -874,10 +780,13 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
+            "version_added": "2.0.0",
+            "version_deprecated": null,
+            "replaced_by": null,
+            "is_default": true,
             "fides_key": "personalize.profiling",
             "organization_fides_key": "default_organization",
             "tags": null,
@@ -888,26 +797,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
-        },
-        {
-            "version_added": "2.0.0",
-            "version_deprecated": null,
-            "replaced_by": null,
-            "is_default": true,
-            "fides_key": "personalize.profiling",
-            "organization_fides_key": "default_organization",
-            "tags": null,
-            "name": "System Personalization",
-            "description": "Personalizes the system.",
-            "parent_key": "personalize",
-            "legal_basis": null,
-            "special_category": null,
-            "recipients": null,
-            "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -941,8 +831,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -959,8 +848,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -977,8 +865,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         },
         {
             "version_added": "2.0.0",
@@ -995,8 +882,7 @@
             "special_category": null,
             "recipients": null,
             "legitimate_interest": null,
-            "legitimate_interest_impact_assessment": null,
-            "is_default": true
+            "legitimate_interest_impact_assessment": null
         }
     ]
 }

--- a/data_files/data_uses.yml
+++ b/data_files/data_uses.yml
@@ -46,18 +46,6 @@ data_use:
   recipients: null
   legitimate_interest: null
   legitimate_interest_impact_assessment: null
-  is_default: true
-- fides_key: analytics.reporting.content_performance
-  organization_fides_key: default_organization
-  tags: null
-  name: Analytics for Content Performance
-  description: Analytics for reporting on content performance.
-  parent_key: analytics.reporting
-  legal_basis: null
-  special_category: null
-  recipients: null
-  legitimate_interest: null
-  legitimate_interest_impact_assessment: null
 - version_added: 2.0.0
   version_deprecated: null
   replaced_by: null
@@ -292,19 +280,6 @@ data_use:
   recipients: null
   legitimate_interest: null
   legitimate_interest_impact_assessment: null
-  is_default: true
-- fides_key: essential.service.security
-  organization_fides_key: default_organization
-  tags: null
-  name: Essential for Security
-  description: Essential to provide security for the product, service, application
-    or system
-  parent_key: essential.service
-  legal_basis: null
-  special_category: null
-  recipients: null
-  legitimate_interest: null
-  legitimate_interest_impact_assessment: null
 - version_added: 2.0.0
   version_deprecated: null
   replaced_by: null
@@ -387,7 +362,7 @@ data_use:
   version_deprecated: null
   replaced_by: null
   is_default: true
-- fides_key: essential.service.operations.improve
+  fides_key: essential.service.operations.improve
   organization_fides_key: default_organization
   tags: null
   name: Essential for Support Improvement
@@ -418,7 +393,7 @@ data_use:
   version_deprecated: null
   replaced_by: null
   is_default: true
-- fides_key: functional
+  fides_key: functional
   organization_fides_key: default_organization
   tags: null
   name: Functional
@@ -433,7 +408,7 @@ data_use:
   version_deprecated: null
   replaced_by: null
   is_default: true
-- fides_key: functional.storage
+  fides_key: functional.storage
   organization_fides_key: default_organization
   tags: null
   name: Local Data Storage
@@ -445,26 +420,17 @@ data_use:
   recipients: null
   legitimate_interest: null
   legitimate_interest_impact_assessment: null
+- version_added: 2.0.0
+  version_deprecated: null
+  replaced_by: null
   is_default: true
-- fides_key: functional.service
+  fides_key: functional.service
   organization_fides_key: default_organization
   tags: null
   name: Service
   description: Functions relating to provided services, products, applications or
     systems.
   parent_key: functional
-  legal_basis: null
-  special_category: null
-  recipients: null
-  legitimate_interest: null
-  legitimate_interest_impact_assessment: null
-  is_default: true
-- fides_key: functional.service.improve
-  organization_fides_key: default_organization
-  tags: null
-  name: Improve Service
-  description: Improves the specific product, service, application or system.
-  parent_key: functional.service
   legal_basis: null
   special_category: null
   recipients: null
@@ -575,30 +541,6 @@ data_use:
   name: Negative Targeting
   description: Enforces rules used to ensure a certain audience or group is not targeted
     by advertising.
-  parent_key: marketing.advertising
-  legal_basis: null
-  special_category: null
-  recipients: null
-  legitimate_interest: null
-  legitimate_interest_impact_assessment: null
-  is_default: true
-- fides_key: marketing.advertising.profiling
-  organization_fides_key: default_organization
-  tags: null
-  name: Profiling for Advertising
-  description: Creates audience profiles for the purpose of targeted advertising
-  parent_key: marketing.advertising
-  legal_basis: null
-  special_category: null
-  recipients: null
-  legitimate_interest: null
-  legitimate_interest_impact_assessment: null
-  is_default: true
-- fides_key: marketing.advertising.serving
-  organization_fides_key: default_organization
-  tags: null
-  name: Essential for Serving Ads
-  description: Essential to the delivery of advertising and content.
   parent_key: marketing.advertising
   legal_basis: null
   special_category: null
@@ -774,18 +716,6 @@ data_use:
   recipients: null
   legitimate_interest: null
   legitimate_interest_impact_assessment: null
-  is_default: true
-- fides_key: personalize.profiling
-  organization_fides_key: default_organization
-  tags: null
-  name: Personalized Profiling
-  description: Creates profiles for the purpose of serving content.
-  parent_key: personalize
-  legal_basis: null
-  special_category: null
-  recipients: null
-  legitimate_interest: null
-  legitimate_interest_impact_assessment: null
 - version_added: 2.0.0
   version_deprecated: null
   replaced_by: null
@@ -793,8 +723,8 @@ data_use:
   fides_key: personalize.profiling
   organization_fides_key: default_organization
   tags: null
-  name: System Personalization
-  description: Personalizes the system.
+  name: Personalized Profiling
+  description: Creates profiles for the purpose of serving content.
   parent_key: personalize
   legal_basis: null
   special_category: null

--- a/mkdocs/docs/csv/data_categories.csv
+++ b/mkdocs/docs/csv/data_categories.csv
@@ -1,173 +1,87 @@
-fides_key,is_default,name,organization_fides_key,parent_key,tags,description
-
-data_category,,Data Category,,,,
-
-system,True,System Data,default_organization,data_category,,"Data unique to, and under control of the system."
-
-system.authentication,True,Authentication Data,default_organization,system,,Data used to manage access to the system.
-
-system.operations,True,Operations Data,default_organization,system,,Data used for system operations.
-
-user,True,User Data,default_organization,data_category,,"Data related to the user of the system, either provided directly or derived based on their usage."
-
-user.account,True,Account Information.,default_organization,user,,Account creation or registration information.
-
-user.authorization,True,Authorization Information.,default_organization,user,,Scope of permissions and access to a system.
-
-user.behavior,True,Observed Behavior,default_organization,user,,Behavioral data about the subject.
-
-user.biometric,True,Biometric Data,default_organization,user,,Encoded characteristics provided by a user.
-
-user.childrens,True,Children's Data,default_organization,user,,Data relating to children.
-
-user.contact,True,Contact Data,default_organization,user,,Contact data collected about a user.
-
-user.content,True,User Content,default_organization,user,,"Content related to, or created by the subject."
-
-user.demographic,True,Demographic Data,default_organization,user,,Demographic data about a user.
-
-user.location,True,Location Data,default_organization,user,,Records of the location of a user.
-
-user.device,True,Device Data,default_organization,user,,"Data related to a user's device, configuration and setting."
-
-user.payment,True,Payment Data,default_organization,user,,Payment data related to user.
-
-user.social,True,Social Data,default_organization,user,,Social activity and interaction data.
-
-user.unique_id,True,Unique ID,default_organization,user,,Unique identifier for a user assigned through system use.
-
-user.telemetry,True,Telemetry Data,default_organization,user,,User identifiable measurement data from system sensors and monitoring.
-
-user.user_sensor,True,User Sensor Data,default_organization,user,,Measurement data about a user's environment through system use.
-
-user.workplace,True,Workplace,default_organization,user,,Organization of employment.
-
-user.sensor,True,Sensor Data,default_organization,user,,Measurement data from sensors and monitoring systems.
-
-user.financial,True,Financial Data,default_organization,user,,Payment data and financial history.
-
-user.government_id,True,Government ID,default_organization,user,,State provided identification data.
-
-user.health_and_medical,True,Health and Medical Data,default_organization,user,,Health records or individual's personal medical information.
-
-user.name,True,Name,default_organization,user,,User's real name.
-
-user.criminal_history,True,Criminal History,default_organization,user,,Criminal records or information about the data subject.
-
-user.privacy_preferences,True,Privacy Preferences,default_organization,user,,Privacy preferences or settings set by the subject.
-
-user.job_title,True,Job Title,default_organization,user,,Professional data.
-
-user.account.settings,True,Account Settings,default_organization,user.account,,Account preferences and settings.
-
-user.account.username,True,Account Username,default_organization,user.account,,Username associated with account.
-
-user.authorization.credentials,True,Account password.,default_organization,user.authorization,,Authentication credentials to a system.
-
-user.authorization.biometric,True,Biometric Credentials,default_organization,user.authorization,,Credentials for system authentication.
-
-user.authorization.password,True,Password,default_organization,user.authorization,,Password for system authentication.
-
-user.behavior.browsing_history,True,Browsing History,default_organization,user.behavior,,Content browsing history of a user.
-
-user.behavior.media_consumption,True,Media Consumption,default_organization,user.behavior,,Content consumption history of the subject.
-
-user.behavior.purchase_history,True,Purchase History,default_organization,user.behavior,,Purchase history of the subject.
-
-user.behavior.search_history,True,Search History,default_organization,user.behavior,,Search history of the subject.
-
-user.biometric.fingerprint,True,Fingerprint,default_organization,user.biometric,,Fingerprint encoded data about a subject.
-
-user.biometric.retinal,True,Retina Scan,default_organization,user.biometric,,Retinal data about a subject.
-
-user.biometric.voice,True,Voice Recording,default_organization,user.biometric,,Voice encoded data about a subject.
-
-user.biometric.health,True,Biometric Health Data,default_organization,user.biometric,,Encoded characteristic collected about a user.
-
-user.contact.address,True,User Contact Address,default_organization,user.contact,,Contact address data collected about a user.
-
-user.contact.email,True,User Contact Email,default_organization,user.contact,,User's contact email address.
-
-user.contact.phone_number,True,User Contact Phone Number,default_organization,user.contact,,User's phone number.
-
-user.contact.url,True,User Website,default_organization,user.contact,,Subject's websites or links to social and personal profiles.
-
-user.contact.fax_number,True,Fax Number,default_organization,user.contact,,Data Subject's fax number.
-
-user.contact.organization,True,Organization,default_organization,user.contact,,Data Subject's Organization.
-
-user.contact.address.city,True,User Contact City,default_organization,user.contact.address,,User's city level address data.
-
-user.contact.address.country,True,User Contact Country,default_organization,user.contact.address,,User's country level address data.
-
-user.contact.address.postal_code,True,User Contact Postal Code,default_organization,user.contact.address,,User's postal code.
-
-user.contact.address.state,True,User Contact State,default_organization,user.contact.address,,User's state level address data.
-
-user.contact.address.street,True,User Contact Street,default_organization,user.contact.address,,User's street level address data.
-
-user.content.private,True,Private Content,default_organization,user.content,,"Private content related to, or created by the subject, not publicly available."
-
-user.content.public,True,Public Content,default_organization,user.content,,"Publicly shared Content related to, or created by the subject."
-
-user.content.self_image,True,User Image,default_organization,user.content,,Photograph or image in which subject is whole or partially recognized.
-
-user.demographic.age_range,True,Age Range,default_organization,user.demographic,,Non specific age or age-range of data subject.
-
-user.demographic.date_of_birth,True,Birth Date,default_organization,user.demographic,,Date of birth of data subject.
-
-user.demographic.gender,True,Gender,default_organization,user.demographic,,Gender of data subject.
-
-user.demographic.language,True,Language,default_organization,user.demographic,,Spoken or written language of subject.
-
-user.demographic.marital_status,True,Marital Status,default_organization,user.demographic,,Marital status of data subject.
-
-user.demographic.political_opinion,True,Political Opinion,default_organization,user.demographic,,Political opinion or belief of data subject.
-
-user.demographic.profile,True,User Profile Data,default_organization,user.demographic,,Profile or preference information about the data subject.
-
-user.demographic.race_ethnicity,True,Race,default_organization,user.demographic,,Race or ethnicity of data subject.
-
-user.demographic.religious_belief,True,Religion,default_organization,user.demographic,,Religion or religious beliefs of the data subject.
-
-user.demographic.sexual_orientation,True,Sexual Orientation,default_organization,user.demographic,,Sexual orientation of data subject.
-
-user.device.cookie,True,Device Cookie,default_organization,user.device,,"Data related to a subject, stored within a cookie."
-
-user.device.cookie_id,True,Cookie ID,default_organization,user.device,,Cookie unique identification number.
-
-user.device.device_id,True,Device ID,default_organization,user.device,,Device unique identification number.
-
-user.device.ip_address,True,IP Address,default_organization,user.device,,Unique identifier related to device connection.
-
-user.financial.bank_account,True,Bank Account Information,default_organization,user.financial,,Bank account information belonging to the subject.
-
-user.financial.credit_card,True,Credit Card Information,default_organization,user.financial,,Credit card information belonging to the subject.
-
-user.government_id.birth_certificate,True,Birth Certificate,default_organization,user.government_id,,State issued certificate of birth.
-
-user.government_id.drivers_license_number,True,Driver's License Number,default_organization,user.government_id,,State issued driving identification number.
-
-user.government_id.immigration,True,Immigration ID,default_organization,user.government_id,,State issued immigration or residency data.
-
-user.government_id.national_identification_number,True,National Identification Number,default_organization,user.government_id,,State issued personal identification number.
-
-user.government_id.passport_number,True,Passport Number,default_organization,user.government_id,,State issued passport data.
-
-user.government_id.vehicle_registration,True,Vehicle Registration,default_organization,user.government_id,,State issued license plate or vehicle registration data.
-
-user.health_and_medical.genetic,True,User's Genetic Data,default_organization,user.health_and_medical,,Data about the genetic makeup provided by the subject.
-
-user.health_and_medical.insurance_beneficiary_id,True,Medical Insurance ID,default_organization,user.health_and_medical,,Health insurance beneficiary number of the subject.
-
-user.health_and_medical.record_id,True,Medical Record ID,default_organization,user.health_and_medical,,Medical record identifiers belonging to a subject.
-
-user.location.imprecise,True,Imprecise Subject Location,default_organization,user.location,,Imprecise location derived from sensors (more than 500M).
-
-user.location.precise,True,Precise Subject Location,default_organization,user.location,,Precise location derived from sensors (less than 500M).
-
-user.name.first,True,First Name,default_organization,user.name,,Subject's first name.
-
-user.name.last,True,Last Name,default_organization,user.name,,"Subject's last, or family, name."
-
-user.unique_id.pseudonymous,True,Pseudonymous User ID,default_organization,user.unique_id,,"A pseudonymous, or probabilistic identifier generated from other subject or device data belonging to the subject."
+fides_key,is_default,name,organization_fides_key,parent_key,replaced_by,tags,version_added,version_deprecated,description
+data_category,,Data Category,,,,,,,
+system,True,System Data,default_organization,data_category,,,2.0.0,,"Data unique to, and under control of the system."
+system.authentication,True,Authentication Data,default_organization,system,,,2.0.0,,Data used to manage access to the system.
+system.operations,True,Operations Data,default_organization,system,,,2.0.0,,Data used for system operations.
+user,True,User Data,default_organization,data_category,,,2.0.0,,"Data related to the user of the system, either provided directly or derived based on their usage."
+user.account,True,Account Information.,default_organization,user,,,2.0.0,,Account creation or registration information.
+user.authorization,True,Authorization Information.,default_organization,user,,,2.0.0,,Scope of permissions and access to a system.
+user.behavior,True,Observed Behavior,default_organization,user,,,2.0.0,,Behavioral data about the subject.
+user.biometric,True,Biometric Data,default_organization,user,,,2.0.0,,Encoded characteristics provided by a user.
+user.childrens,True,Children's Data,default_organization,user,,,2.0.0,,Data relating to children.
+user.contact,True,Contact Data,default_organization,user,,,2.0.0,,Contact data collected about a user.
+user.content,True,User Content,default_organization,user,,,2.0.0,,"Content related to, or created by the subject."
+user.demographic,True,Demographic Data,default_organization,user,,,2.0.0,,Demographic data about a user.
+user.location,True,Location Data,default_organization,user,,,2.0.0,,Records of the location of a user.
+user.device,True,Device Data,default_organization,user,,,2.0.0,,"Data related to a user's device, configuration and setting."
+user.payment,True,Payment Data,default_organization,user,,,2.0.0,,Payment data related to user.
+user.social,True,Social Data,default_organization,user,,,2.0.0,,Social activity and interaction data.
+user.unique_id,True,Unique ID,default_organization,user,,,2.0.0,,Unique identifier for a user assigned through system use.
+user.telemetry,True,Telemetry Data,default_organization,user,,,2.0.0,,User identifiable measurement data from system sensors and monitoring.
+user.user_sensor,True,User Sensor Data,default_organization,user,,,2.0.0,,Measurement data about a user's environment through system use.
+user.workplace,True,Workplace,default_organization,user,,,2.0.0,,Organization of employment.
+user.sensor,True,Sensor Data,default_organization,user,,,2.0.0,,Measurement data from sensors and monitoring systems.
+user.financial,True,Financial Data,default_organization,user,,,2.0.0,,Payment data and financial history.
+user.government_id,True,Government ID,default_organization,user,,,2.0.0,,State provided identification data.
+user.health_and_medical,True,Health and Medical Data,default_organization,user,,,2.0.0,,Health records or individual's personal medical information.
+user.name,True,Name,default_organization,user,,,2.0.0,,User's real name.
+user.criminal_history,True,Criminal History,default_organization,user,,,2.0.0,,Criminal records or information about the data subject.
+user.privacy_preferences,True,Privacy Preferences,default_organization,user,,,2.0.0,,Privacy preferences or settings set by the subject.
+user.job_title,True,Job Title,default_organization,user,,,2.0.0,,Professional data.
+user.account.settings,True,Account Settings,default_organization,user.account,,,2.0.0,,Account preferences and settings.
+user.account.username,True,Account Username,default_organization,user.account,,,2.0.0,,Username associated with account.
+user.authorization.credentials,True,Account password.,default_organization,user.authorization,,,2.0.0,,Authentication credentials to a system.
+user.authorization.biometric,True,Biometric Credentials,default_organization,user.authorization,,,2.0.0,,Credentials for system authentication.
+user.authorization.password,True,Password,default_organization,user.authorization,,,2.0.0,,Password for system authentication.
+user.behavior.browsing_history,True,Browsing History,default_organization,user.behavior,,,2.0.0,,Content browsing history of a user.
+user.behavior.media_consumption,True,Media Consumption,default_organization,user.behavior,,,2.0.0,,Content consumption history of the subject.
+user.behavior.purchase_history,True,Purchase History,default_organization,user.behavior,,,2.0.0,,Purchase history of the subject.
+user.behavior.search_history,True,Search History,default_organization,user.behavior,,,2.0.0,,Search history of the subject.
+user.biometric.fingerprint,True,Fingerprint,default_organization,user.biometric,,,2.0.0,,Fingerprint encoded data about a subject.
+user.biometric.retinal,True,Retina Scan,default_organization,user.biometric,,,2.0.0,,Retinal data about a subject.
+user.biometric.voice,True,Voice Recording,default_organization,user.biometric,,,2.0.0,,Voice encoded data about a subject.
+user.biometric.health,True,Biometric Health Data,default_organization,user.biometric,,,2.0.0,,Encoded characteristic collected about a user.
+user.contact.address,True,User Contact Address,default_organization,user.contact,,,2.0.0,,Contact address data collected about a user.
+user.contact.email,True,User Contact Email,default_organization,user.contact,,,2.0.0,,User's contact email address.
+user.contact.phone_number,True,User Contact Phone Number,default_organization,user.contact,,,2.0.0,,User's phone number.
+user.contact.url,True,User Website,default_organization,user.contact,,,2.0.0,,Subject's websites or links to social and personal profiles.
+user.contact.fax_number,True,Fax Number,default_organization,user.contact,,,2.0.0,,Data Subject's fax number.
+user.contact.organization,True,Organization,default_organization,user.contact,,,2.0.0,,Data Subject's Organization.
+user.contact.address.city,True,User Contact City,default_organization,user.contact.address,,,2.0.0,,User's city level address data.
+user.contact.address.country,True,User Contact Country,default_organization,user.contact.address,,,2.0.0,,User's country level address data.
+user.contact.address.postal_code,True,User Contact Postal Code,default_organization,user.contact.address,,,2.0.0,,User's postal code.
+user.contact.address.state,True,User Contact State,default_organization,user.contact.address,,,2.0.0,,User's state level address data.
+user.contact.address.street,True,User Contact Street,default_organization,user.contact.address,,,2.0.0,,User's street level address data.
+user.content.private,True,Private Content,default_organization,user.content,,,2.0.0,,"Private content related to, or created by the subject, not publicly available."
+user.content.public,True,Public Content,default_organization,user.content,,,2.0.0,,"Publicly shared Content related to, or created by the subject."
+user.content.self_image,True,User Image,default_organization,user.content,,,2.0.0,,Photograph or image in which subject is whole or partially recognized.
+user.demographic.age_range,True,Age Range,default_organization,user.demographic,,,2.0.0,,Non specific age or age-range of data subject.
+user.demographic.date_of_birth,True,Birth Date,default_organization,user.demographic,,,2.0.0,,Date of birth of data subject.
+user.demographic.gender,True,Gender,default_organization,user.demographic,,,2.0.0,,Gender of data subject.
+user.demographic.language,True,Language,default_organization,user.demographic,,,2.0.0,,Spoken or written language of subject.
+user.demographic.marital_status,True,Marital Status,default_organization,user.demographic,,,2.0.0,,Marital status of data subject.
+user.demographic.political_opinion,True,Political Opinion,default_organization,user.demographic,,,2.0.0,,Political opinion or belief of data subject.
+user.demographic.profile,True,User Profile Data,default_organization,user.demographic,,,2.0.0,,Profile or preference information about the data subject.
+user.demographic.race_ethnicity,True,Race,default_organization,user.demographic,,,2.0.0,,Race or ethnicity of data subject.
+user.demographic.religious_belief,True,Religion,default_organization,user.demographic,,,2.0.0,,Religion or religious beliefs of the data subject.
+user.demographic.sexual_orientation,True,Sexual Orientation,default_organization,user.demographic,,,2.0.0,,Sexual orientation of data subject.
+user.device.cookie,True,Device Cookie,default_organization,user.device,,,2.0.0,,"Data related to a subject, stored within a cookie."
+user.device.cookie_id,True,Cookie ID,default_organization,user.device,,,2.0.0,,Cookie unique identification number.
+user.device.device_id,True,Device ID,default_organization,user.device,,,2.0.0,,Device unique identification number.
+user.device.ip_address,True,IP Address,default_organization,user.device,,,2.0.0,,Unique identifier related to device connection.
+user.financial.bank_account,True,Bank Account Information,default_organization,user.financial,,,2.0.0,,Bank account information belonging to the subject.
+user.financial.credit_card,True,Credit Card Information,default_organization,user.financial,,,2.0.0,,Credit card information belonging to the subject.
+user.government_id.birth_certificate,True,Birth Certificate,default_organization,user.government_id,,,2.0.0,,State issued certificate of birth.
+user.government_id.drivers_license_number,True,Driver's License Number,default_organization,user.government_id,,,2.0.0,,State issued driving identification number.
+user.government_id.immigration,True,Immigration ID,default_organization,user.government_id,,,2.0.0,,State issued immigration or residency data.
+user.government_id.national_identification_number,True,National Identification Number,default_organization,user.government_id,,,2.0.0,,State issued personal identification number.
+user.government_id.passport_number,True,Passport Number,default_organization,user.government_id,,,2.0.0,,State issued passport data.
+user.government_id.vehicle_registration,True,Vehicle Registration,default_organization,user.government_id,,,2.0.0,,State issued license plate or vehicle registration data.
+user.health_and_medical.genetic,True,User's Genetic Data,default_organization,user.health_and_medical,,,2.0.0,,Data about the genetic makeup provided by the subject.
+user.health_and_medical.insurance_beneficiary_id,True,Medical Insurance ID,default_organization,user.health_and_medical,,,2.0.0,,Health insurance beneficiary number of the subject.
+user.health_and_medical.record_id,True,Medical Record ID,default_organization,user.health_and_medical,,,2.0.0,,Medical record identifiers belonging to a subject.
+user.location.imprecise,True,Imprecise Subject Location,default_organization,user.location,,,2.0.0,,Imprecise location derived from sensors (more than 500M).
+user.location.precise,True,Precise Subject Location,default_organization,user.location,,,2.0.0,,Precise location derived from sensors (less than 500M).
+user.name.first,True,First Name,default_organization,user.name,,,2.0.0,,Subject's first name.
+user.name.last,True,Last Name,default_organization,user.name,,,2.0.0,,"Subject's last, or family, name."
+user.unique_id.pseudonymous,True,Pseudonymous User ID,default_organization,user.unique_id,,,2.0.0,,"A pseudonymous, or probabilistic identifier generated from other subject or device data belonging to the subject."

--- a/mkdocs/docs/csv/data_qualifiers.csv
+++ b/mkdocs/docs/csv/data_qualifiers.csv
@@ -1,13 +1,7 @@
-fides_key,is_default,name,organization_fides_key,parent_key,tags,description
-
-data_qualifier,,Data Qualifier,,,,
-
-aggregated,True,Aggregated Data,default_organization,data_qualifier,,Statistical data that does not contain individually identifying information but includes information about groups of individuals that renders individual identification impossible.
-
-aggregated.anonymized,True,Anonymized Data,default_organization,aggregated,,Data where all attributes have been sufficiently altered that the individaul cannot be reidentified by this data or in combination with other datasets.
-
-aggregated.anonymized.unlinked_pseudonymized,True,Unlinked Pseudonymized Data,default_organization,aggregated.anonymized,,"Data for which all identifiers have been substituted with unrelated values and linkages broken such that it may not be reversed, even by the party that performed the pseudonymization."
-
-aggregated.anonymized.unlinked_pseudonymized.pseudonymized,True,Pseudonymized Data,default_organization,aggregated.anonymized.unlinked_pseudonymized,,"Data for which all identifiers have been substituted with unrelated values, rendering the individual unidentifiable and cannot be reasonably reversed other than by the party that performed the pseudonymization."
-
-aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified,True,Identified Data,default_organization,aggregated.anonymized.unlinked_pseudonymized.pseudonymized,,Data that directly identifies an individual.
+fides_key,is_default,name,organization_fides_key,parent_key,replaced_by,tags,version_added,version_deprecated,description
+data_qualifier,,Data Qualifier,,,,,,,
+aggregated,True,Aggregated Data,default_organization,data_qualifier,,,2.0.0,,Statistical data that does not contain individually identifying information but includes information about groups of individuals that renders individual identification impossible.
+aggregated.anonymized,True,Anonymized Data,default_organization,aggregated,,,2.0.0,,Data where all attributes have been sufficiently altered that the individaul cannot be reidentified by this data or in combination with other datasets.
+aggregated.anonymized.unlinked_pseudonymized,True,Unlinked Pseudonymized Data,default_organization,aggregated.anonymized,,,2.0.0,,"Data for which all identifiers have been substituted with unrelated values and linkages broken such that it may not be reversed, even by the party that performed the pseudonymization."
+aggregated.anonymized.unlinked_pseudonymized.pseudonymized,True,Pseudonymized Data,default_organization,aggregated.anonymized.unlinked_pseudonymized,,,2.0.0,,"Data for which all identifiers have been substituted with unrelated values, rendering the individual unidentifiable and cannot be reasonably reversed other than by the party that performed the pseudonymization."
+aggregated.anonymized.unlinked_pseudonymized.pseudonymized.identified,True,Identified Data,default_organization,aggregated.anonymized.unlinked_pseudonymized.pseudonymized,,,2.0.0,,Data that directly identifies an individual.

--- a/mkdocs/docs/csv/data_subjects.csv
+++ b/mkdocs/docs/csv/data_subjects.csv
@@ -1,33 +1,17 @@
-automated_decisions_or_profiling,fides_key,is_default,name,organization_fides_key,rights,tags,parent_key,description
-
-,data_subject,,Data Subject,,,,,
-
-,anonymous_user,True,Anonymous User,default_organization,,,data_subject,An individual that is unidentifiable to the systems. Note - This should only be applied to truly anonymous users where there is no risk of re-identification
-
-,citizen_voter,True,Citizen Voter,default_organization,,,data_subject,An individual registered to voter with a state or authority.
-
-,commuter,True,Commuter,default_organization,,,data_subject,An individual that is traveling or transiting in the context of location tracking.
-
-,consultant,True,Consultant,default_organization,,,data_subject,An individual employed in a consultative/temporary capacity by the organization.
-
-,customer,True,Customer,default_organization,,,data_subject,An individual or other organization that purchases goods or services from the organization.
-
-,employee,True,Employee,default_organization,,,data_subject,An individual employed by the organization.
-
-,job_applicant,True,Job Applicant,default_organization,,,data_subject,An individual applying for employment to the organization.
-
-,next_of_kin,True,Next of Kin,default_organization,,,data_subject,A relative of any other individual subject where such a relationship is known.
-
-,passenger,True,Passenger,default_organization,,,data_subject,An individual traveling on some means of provided transport.
-
-,patient,True,Patient,default_organization,,,data_subject,An individual identified for the purposes of any medical care.
-
-,prospect,True,Prospect,default_organization,,,data_subject,An individual or organization to whom an organization is selling goods or services.
-
-,shareholder,True,Shareholder,default_organization,,,data_subject,An individual or organization that holds equity in the organization.
-
-,supplier_vendor,True,Supplier/Vendor,default_organization,,,data_subject,An individual or organization that provides services or goods to the organization.
-
-,trainee,True,Trainee,default_organization,,,data_subject,An individual undergoing training by the organization.
-
-,visitor,True,Visitor,default_organization,,,data_subject,An individual visiting a location.
+automated_decisions_or_profiling,fides_key,is_default,name,organization_fides_key,replaced_by,rights,tags,version_added,version_deprecated,parent_key,description
+,data_subject,,Data Subject,,,,,,,,
+,anonymous_user,True,Anonymous User,default_organization,,,,2.0.0,,data_subject,An individual that is unidentifiable to the systems. Note - This should only be applied to truly anonymous users where there is no risk of re-identification
+,citizen_voter,True,Citizen Voter,default_organization,,,,2.0.0,,data_subject,An individual registered to voter with a state or authority.
+,commuter,True,Commuter,default_organization,,,,2.0.0,,data_subject,An individual that is traveling or transiting in the context of location tracking.
+,consultant,True,Consultant,default_organization,,,,2.0.0,,data_subject,An individual employed in a consultative/temporary capacity by the organization.
+,customer,True,Customer,default_organization,,,,2.0.0,,data_subject,An individual or other organization that purchases goods or services from the organization.
+,employee,True,Employee,default_organization,,,,2.0.0,,data_subject,An individual employed by the organization.
+,job_applicant,True,Job Applicant,default_organization,,,,2.0.0,,data_subject,An individual applying for employment to the organization.
+,next_of_kin,True,Next of Kin,default_organization,,,,2.0.0,,data_subject,A relative of any other individual subject where such a relationship is known.
+,passenger,True,Passenger,default_organization,,,,2.0.0,,data_subject,An individual traveling on some means of provided transport.
+,patient,True,Patient,default_organization,,,,2.0.0,,data_subject,An individual identified for the purposes of any medical care.
+,prospect,True,Prospect,default_organization,,,,2.0.0,,data_subject,An individual or organization to whom an organization is selling goods or services.
+,shareholder,True,Shareholder,default_organization,,,,2.0.0,,data_subject,An individual or organization that holds equity in the organization.
+,supplier_vendor,True,Supplier/Vendor,default_organization,,,,2.0.0,,data_subject,An individual or organization that provides services or goods to the organization.
+,trainee,True,Trainee,default_organization,,,,2.0.0,,data_subject,An individual undergoing training by the organization.
+,visitor,True,Visitor,default_organization,,,,2.0.0,,data_subject,An individual visiting a location.

--- a/mkdocs/docs/csv/data_uses.csv
+++ b/mkdocs/docs/csv/data_uses.csv
@@ -1,107 +1,54 @@
-fides_key,is_default,legal_basis,legitimate_interest,legitimate_interest_impact_assessment,name,organization_fides_key,parent_key,recipients,special_category,tags,description
-
-data_use,,,,,Data Use,,,,,,
-
-analytics,True,,,,Analytics,default_organization,data_use,,,,"Provides analytics for activities such as system and advertising performance reporting, insights and fraud detection."
-
-analytics.reporting,True,,,,Analytics for Reporting,default_organization,analytics,,,,Provides analytics for general reporting such as system and advertising performance.
-
-analytics.reporting.ad_performance,True,,,,Analytics for Advertising Performance,default_organization,analytics.reporting,,,,Provides analytics for reporting of advertising performance.
-
-analytics.reporting.content_performance,True,,,,Analytics for Content Performance,default_organization,analytics.reporting,,,,Analytics for reporting on content performance.
-
-analytics.reporting.campaign_insights,True,,,,Analytics for Insights,default_organization,analytics.reporting,,,,Provides analytics for reporting of campaign insights related to advertising and promotion activities.
-
-analytics.reporting.system,True,,,,Analytics for System Activity,default_organization,analytics.reporting,,,,Provides analytics for reporting on system activity.
-
-analytics.reporting.system.performance,True,,,,Analytics for System Performance,default_organization,analytics.reporting.system,,,,Provides analytics for reporting on system performance.
-
-collect,True,,,,Collect,default_organization,data_use,,,,Collects or stores data in order to use it for another purpose which has not yet been expressly defined.
-
-employment,True,,,,Employment,default_organization,data_use,,,,Processes data for the purpose of recruitment or employment and human resources (HR) related activities.
-
-employment.recruitment,True,,,,Employment Recruitment,default_organization,employment,,,,Processes data of prospective employees for the purpose of recruitment.
-
-essential,True,,,,Essential,default_organization,data_use,,,,"Operates the service or product, including legal obligations, support and basic system operations."
-
-essential.fraud_detection,True,,,,Essential Fraud Detection,default_organization,essential,,,,"Detects possible fraud or misuse of the product, service, application or system."
-
-essential.legal_obligation,True,,,,Essential Legal Obligation,default_organization,essential,,,,Provides service to meet a legal or compliance obligation such as consent management.
-
-essential.service,True,,,,Essential for Service,default_organization,essential,,,,"Provides the essential product, service, application or system, without which the product/service would not be possible."
-
-essential.service.authentication,True,,,,Essential Service Authentication,default_organization,essential.service,,,,"Authenticate users to the product, service, application or system."
-
-essential.service.notifications,True,,,,Essential Service Notifications,default_organization,essential.service,,,,"Sends notifications about the product, service, application or system."
-
-essential.service.operations,True,,,,Essential for Operations,default_organization,essential.service,,,,"Essential to ensure the operation of the product, service, application or system."
-
-essential.service.payment_processing,True,,,,Essential for Payment Processing,default_organization,essential.service,,,,"Essential to processes payments for the product, service, application or system."
-
-essential.service.security,True,,,,Essential for Security,default_organization,essential.service,,,,"Essential to provide security for the product, service, application or system"
-
-essential.service.upgrades,True,,,,Essential for Service Upgrades,default_organization,essential.service,,,,Provides timely system upgrade information options.
-
-essential.service.notifications.email,True,,,,Essential Email Service Notifications,default_organization,essential.service.notifications,,,,"Sends email notifications about the product, service, application or system."
-
-essential.service.notifications.sms,True,,,,Essential SMS Service Notifications,default_organization,essential.service.notifications,,,,"Sends SMS notifications about the product, service, application or system."
-
-essential.service.operations.support,True,,,,Essential for Operations Support,default_organization,essential.service.operations,,,,"Provides support for the product, service, application or system."
-
-essential.service.operations.improve,True,,,,Essential for Support Improvement,default_organization,essential.service.operations,,,,"Essential to optimize and improve support for the product, service, application or system."
-
-finance,True,,,,Finance,default_organization,data_use,,,,Enables finance and accounting activities such as audits and tax reporting.
-
-functional,True,,,,Functional,default_organization,data_use,,,,"Used for specific, necessary, and legitimate purposes"
-
-functional.storage,True,,,,Local Data Storage,default_organization,functional,,,,"Stores or accesses information from the device as needed when using a product, service, application, or system"
-
-functional.service,True,,,,Service,default_organization,functional,,,,"Functions relating to provided services, products, applications or systems."
-
-functional.service.improve,True,,,,Improve Service,default_organization,functional.service,,,,"Improves the specific product, service, application or system."
-
-marketing,True,,,,Marketing,default_organization,data_use,,,,"Enables marketing, promotion, advertising and sales activities for the product, service, application or system."
-
-marketing.advertising,True,,,,"Advertising, Marketing or Promotion",default_organization,marketing,,,,"Advertises or promotes the product, service, application or system and associated services."
-
-marketing.communications,True,,,,Marketing Communications,default_organization,marketing,,,,"Uses combined channels to message and market to a customer, user or prospect."
-
-marketing.advertising.first_party,True,,,,First Party Advertising,default_organization,marketing.advertising,,,,Serves advertisements based on first party data collected or derived about the user.
-
-marketing.advertising.frequency_capping,True,,,,Frequency Capping,default_organization,marketing.advertising,,,,Restricts the number of times a specific advertisement is shown to an individual.
-
-marketing.advertising.negative_targeting,True,,,,Negative Targeting,default_organization,marketing.advertising,,,,Enforces rules used to ensure a certain audience or group is not targeted by advertising.
-
-marketing.advertising.profiling,True,,,,Profiling for Advertising,default_organization,marketing.advertising,,,,Creates audience profiles for the purpose of targeted advertising
-
-marketing.advertising.serving,True,,,,Essential for Serving Ads,default_organization,marketing.advertising,,,,Essential to the delivery of advertising and content.
-
-marketing.advertising.third_party,True,,,,Third Party Advertising,default_organization,marketing.advertising,,,,Serves advertisements based on data within the system or joined with data provided by 3rd parties.
-
-marketing.advertising.first_party.contextual,True,,,,First Party Contextual Advertising,default_organization,marketing.advertising.first_party,,,,Serves advertisements based on current content being viewed by the user of the system or service.
-
-marketing.advertising.first_party.targeted,True,,,,First Party Personalized Advertising,default_organization,marketing.advertising.first_party,,,,Targets advertisements based on data collected or derived about the user from use of the system.
-
-marketing.advertising.third_party.targeted,True,,,,Third Party Targeted Advertising,default_organization,marketing.advertising.third_party,,,,Targets advertisements based on data within the system or joined with data provided by 3rd parties.
-
-marketing.communications.email,True,,,,Marketing Email Communications,default_organization,marketing.communications,,,,Sends email marketing communications.
-
-marketing.communications.sms,True,,,,Marketing SMS Communications,default_organization,marketing.communications,,,,Sends SMS marketing communications.
-
-operations,True,,,,Operations,default_organization,data_use,,,,Supports business processes necessary to the organization's operation.
-
-personalize,True,,,,Personalize,default_organization,data_use,,,,"Personalizes the product, service, application or system."
-
-personalize.content,True,,,,Content Personalization,default_organization,personalize,,,,"Personalizes the content of the product, service, application or system."
-
-personalize.profiling,True,,,,Personalized Profiling,default_organization,personalize,,,,Creates profiles for the purpose of serving content.
-
-personalize.system,True,,,,System Personalization,default_organization,personalize,,,,Personalizes the system.
-
-sales,True,,,,Sales,default_organization,data_use,,,,Supports sales activities such as communications and outreach.
-
-third_party_sharing,True,,,,Third Party Sharing,default_organization,data_use,,,,Transfers data to third parties outside of the system or service's scope.
-
-third_party_sharing.legal_obligation,True,,,,Sharing for Legal Obligation,default_organization,third_party_sharing,,,,"Shares data for legal obligations, including contracts, applicable laws or regulations."
-
-train_ai_system,True,,,,Train AI System,default_organization,data_use,,,,Trains an AI system or data model for machine learning.
+fides_key,is_default,legal_basis,legitimate_interest,legitimate_interest_impact_assessment,name,organization_fides_key,parent_key,recipients,replaced_by,special_category,tags,version_added,version_deprecated,description
+data_use,,,,,Data Use,,,,,,,,,
+analytics,True,,,,Analytics,default_organization,data_use,,,,,2.0.0,,"Provides analytics for activities such as system and advertising performance reporting, insights and fraud detection."
+analytics.reporting,True,,,,Analytics for Reporting,default_organization,analytics,,,,,2.0.0,,Provides analytics for general reporting such as system and advertising performance.
+analytics.reporting.ad_performance,True,,,,Analytics for Advertising Performance,default_organization,analytics.reporting,,,,,2.0.0,,Provides analytics for reporting of advertising performance.
+analytics.reporting.content_performance,True,,,,Analytics for Content Performance,default_organization,analytics.reporting,,,,,2.0.0,,Analytics for reporting on content performance.
+analytics.reporting.campaign_insights,True,,,,Analytics for Insights,default_organization,analytics.reporting,,,,,2.0.0,,Provides analytics for reporting of campaign insights related to advertising and promotion activities.
+analytics.reporting.system,True,,,,Analytics for System Activity,default_organization,analytics.reporting,,,,,2.0.0,,Provides analytics for reporting on system activity.
+analytics.reporting.system.performance,True,,,,Analytics for System Performance,default_organization,analytics.reporting.system,,,,,2.0.0,,Provides analytics for reporting on system performance.
+collect,True,,,,Collect,default_organization,data_use,,,,,2.0.0,,Collects or stores data in order to use it for another purpose which has not yet been expressly defined.
+employment,True,,,,Employment,default_organization,data_use,,,,,2.0.0,,Processes data for the purpose of recruitment or employment and human resources (HR) related activities.
+employment.recruitment,True,,,,Employment Recruitment,default_organization,employment,,,,,2.0.0,,Processes data of prospective employees for the purpose of recruitment.
+essential,True,,,,Essential,default_organization,data_use,,,,,2.0.0,,"Operates the service or product, including legal obligations, support and basic system operations."
+essential.fraud_detection,True,,,,Essential Fraud Detection,default_organization,essential,,,,,2.0.0,,"Detects possible fraud or misuse of the product, service, application or system."
+essential.legal_obligation,True,,,,Essential Legal Obligation,default_organization,essential,,,,,2.0.0,,Provides service to meet a legal or compliance obligation such as consent management.
+essential.service,True,,,,Essential for Service,default_organization,essential,,,,,2.0.0,,"Provides the essential product, service, application or system, without which the product/service would not be possible."
+essential.service.authentication,True,,,,Essential Service Authentication,default_organization,essential.service,,,,,2.0.0,,"Authenticate users to the product, service, application or system."
+essential.service.notifications,True,,,,Essential Service Notifications,default_organization,essential.service,,,,,2.0.0,,"Sends notifications about the product, service, application or system."
+essential.service.operations,True,,,,Essential for Operations,default_organization,essential.service,,,,,2.0.0,,"Essential to ensure the operation of the product, service, application or system."
+essential.service.payment_processing,True,,,,Essential for Payment Processing,default_organization,essential.service,,,,,2.0.0,,"Essential to processes payments for the product, service, application or system."
+essential.service.security,True,,,,Essential for Security,default_organization,essential.service,,,,,2.0.0,,"Essential to provide security for the product, service, application or system"
+essential.service.upgrades,True,,,,Essential for Service Upgrades,default_organization,essential.service,,,,,2.0.0,,Provides timely system upgrade information options.
+essential.service.notifications.email,True,,,,Essential Email Service Notifications,default_organization,essential.service.notifications,,,,,2.0.0,,"Sends email notifications about the product, service, application or system."
+essential.service.notifications.sms,True,,,,Essential SMS Service Notifications,default_organization,essential.service.notifications,,,,,2.0.0,,"Sends SMS notifications about the product, service, application or system."
+essential.service.operations.support,True,,,,Essential for Operations Support,default_organization,essential.service.operations,,,,,2.0.0,,"Provides support for the product, service, application or system."
+essential.service.operations.improve,True,,,,Essential for Support Improvement,default_organization,essential.service.operations,,,,,2.0.0,,"Essential to optimize and improve support for the product, service, application or system."
+finance,True,,,,Finance,default_organization,data_use,,,,,2.0.0,,Enables finance and accounting activities such as audits and tax reporting.
+functional,True,,,,Functional,default_organization,data_use,,,,,2.0.0,,"Used for specific, necessary, and legitimate purposes"
+functional.storage,True,,,,Local Data Storage,default_organization,functional,,,,,2.0.0,,"Stores or accesses information from the device as needed when using a product, service, application, or system"
+functional.service,True,,,,Service,default_organization,functional,,,,,2.0.0,,"Functions relating to provided services, products, applications or systems."
+functional.service.improve,True,,,,Improve Service,default_organization,functional.service,,,,,2.0.0,,"Improves the specific product, service, application or system."
+marketing,True,,,,Marketing,default_organization,data_use,,,,,2.0.0,,"Enables marketing, promotion, advertising and sales activities for the product, service, application or system."
+marketing.advertising,True,,,,"Advertising, Marketing or Promotion",default_organization,marketing,,,,,2.0.0,,"Advertises or promotes the product, service, application or system and associated services."
+marketing.communications,True,,,,Marketing Communications,default_organization,marketing,,,,,2.0.0,,"Uses combined channels to message and market to a customer, user or prospect."
+marketing.advertising.first_party,True,,,,First Party Advertising,default_organization,marketing.advertising,,,,,2.0.0,,Serves advertisements based on first party data collected or derived about the user.
+marketing.advertising.frequency_capping,True,,,,Frequency Capping,default_organization,marketing.advertising,,,,,2.0.0,,Restricts the number of times a specific advertisement is shown to an individual.
+marketing.advertising.negative_targeting,True,,,,Negative Targeting,default_organization,marketing.advertising,,,,,2.0.0,,Enforces rules used to ensure a certain audience or group is not targeted by advertising.
+marketing.advertising.profiling,True,,,,Profiling for Advertising,default_organization,marketing.advertising,,,,,2.0.0,,Creates audience profiles for the purpose of targeted advertising
+marketing.advertising.serving,True,,,,Essential for Serving Ads,default_organization,marketing.advertising,,,,,2.0.0,,Essential to the delivery of advertising and content.
+marketing.advertising.third_party,True,,,,Third Party Advertising,default_organization,marketing.advertising,,,,,2.0.0,,Serves advertisements based on data within the system or joined with data provided by 3rd parties.
+marketing.advertising.first_party.contextual,True,,,,First Party Contextual Advertising,default_organization,marketing.advertising.first_party,,,,,2.0.0,,Serves advertisements based on current content being viewed by the user of the system or service.
+marketing.advertising.first_party.targeted,True,,,,First Party Personalized Advertising,default_organization,marketing.advertising.first_party,,,,,2.0.0,,Targets advertisements based on data collected or derived about the user from use of the system.
+marketing.advertising.third_party.targeted,True,,,,Third Party Targeted Advertising,default_organization,marketing.advertising.third_party,,,,,2.0.0,,Targets advertisements based on data within the system or joined with data provided by 3rd parties.
+marketing.communications.email,True,,,,Marketing Email Communications,default_organization,marketing.communications,,,,,2.0.0,,Sends email marketing communications.
+marketing.communications.sms,True,,,,Marketing SMS Communications,default_organization,marketing.communications,,,,,2.0.0,,Sends SMS marketing communications.
+operations,True,,,,Operations,default_organization,data_use,,,,,2.0.0,,Supports business processes necessary to the organization's operation.
+personalize,True,,,,Personalize,default_organization,data_use,,,,,2.0.0,,"Personalizes the product, service, application or system."
+personalize.content,True,,,,Content Personalization,default_organization,personalize,,,,,2.0.0,,"Personalizes the content of the product, service, application or system."
+personalize.profiling,True,,,,Personalized Profiling,default_organization,personalize,,,,,2.0.0,,Creates profiles for the purpose of serving content.
+personalize.system,True,,,,System Personalization,default_organization,personalize,,,,,2.0.0,,Personalizes the system.
+sales,True,,,,Sales,default_organization,data_use,,,,,2.0.0,,Supports sales activities such as communications and outreach.
+third_party_sharing,True,,,,Third Party Sharing,default_organization,data_use,,,,,2.0.0,,Transfers data to third parties outside of the system or service's scope.
+third_party_sharing.legal_obligation,True,,,,Sharing for Legal Obligation,default_organization,third_party_sharing,,,,,2.0.0,,"Shares data for legal obligations, including contracts, applicable laws or regulations."
+train_ai_system,True,,,,Train AI System,default_organization,data_use,,,,,2.0.0,,Trains an AI system or data model for machine learning.


### PR DESCRIPTION
### Description Of Changes

This fixes the taxonomy explorer for `fideslang` 2.0.0 by addressing a curious and annoying issue - it looks like the export script, when run on a Windows machine, seems to introduce spurious empty lines into the CSV. This fools the d3 scripts we have in the docs site into creating invalid empty nodes!

When this occurs, the docs site renders an empty tree:
<img width="1411" alt="image" src="https://github.com/ethyca/fideslang/assets/1834295/81ea4860-e542-4721-a057-51d82befa0ac">

The "fix" for this was trivial... I just re-ran `python scripts/export_default_taxonomy.py` locally and regenerated the CSVs on my Mac. This results in output without empty lines and everything parses nicely. (side-note: the data files were out of date, so this also updated them with the new fields/etc.)

To help catch this in the future, this also includes a CI check that runs a really rough validation on the CSV. This'd probably make more sense as a pytest suite, but I have to admit I'm quick to reach for `grep` when it's an option... see this failed action for this CI check _correctly_ failing on this PR before I updated the files: https://github.com/ethyca/fideslang/actions/runs/5897911662/job/15998195678?pr=154
![image](https://github.com/ethyca/fideslang/assets/1834295/ca2d691f-2f22-426c-8833-66b6336f22d9)


### Code Changes

* [X] Re-run `python scripts/export_default_taxonomy.py` in a venv locally
* [X] Add a CI check that does some cursed `grep` tricks to detect empty lines

### Steps to Confirm

* [X] Ran locally and used `make docs-serve` to confirm the site looks good:
<img width="1403" alt="image" src="https://github.com/ethyca/fideslang/assets/1834295/b634417d-99e6-4d2e-ae5f-1123786fad4a">


### Pre-Merge Checklist

* [X] All CI Pipelines Succeeded
* [X] Documentation Updated
* [X] Issue Requirements are Met
* [X] Relevant Follow-Up Issues Created
* [X] Update `CHANGELOG.md`
