### PR TITLE
update changelog for 2.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fideslang/compare/2.0.1...main)
+## [Unreleased](https://github.com/ethyca/fideslang/compare/2.0.2...main)
+
+## [2.0.2](https://github.com/ethyca/fideslang/compare/2.0.1...2.0.2)
 
 ### Changed
 
@@ -36,6 +38,12 @@ The types of changes are:
 
 - Updated the Data Categories and Data Uses to support GVL [#144](https://github.com/ethyca/fideslang/pull/144)
 - Add version metadata to the default taxonomy items [#147](https://github.com/ethyca/fideslang/pull/147)
+
+## [1.4.5 (Hotfix)](https://github.com/ethyca/fideslang/compare/1.4.4...1.4.5)
+
+### Changed
+
+- Update `system.legal_basis_for_profiling` and `system.legal_basis_for_transfers` fields [#156](https://github.com/ethyca/fideslang/pull/156)
 
 ## [1.4.4](https://github.com/ethyca/fideslang/compare/1.4.3...1.4.4)
 


### PR DESCRIPTION
Closes n/a

### Description Of Changes

will release `2.0.2` against this commit, to get us a `2.0.x` release of `fideslang` that includes https://github.com/ethyca/fideslang/pull/156 to be pulled in for `fides` integration

i figured it'd make sense to update our `CHANGELOG.md` with an entry for the `1.4.5` hotfix release to make sure that's tracked in our `main` changelog. but i'd be happy to remove if this doesn't seem right to others

### Code Changes

* [x] update changelog

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
