### PR TITLE
Relax System Legal Basis for Transfers

### DIFF
--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -229,7 +229,7 @@ class LegalBasisForTransfersEnum(str, Enum):
     The model for describing the legal basis under which data is transferred
 
     We currently do _not_ enforce this enum on the `legal_basis_for_transfers`
-    field, because the set of allowable values seems to be changing frequently 
+    field, because the set of allowable values seems to be changing frequently
     and without clear notice in upstream, public data sources.
     """
 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -225,7 +225,13 @@ class LegalBasisForProfilingEnum(str, Enum):
 
 
 class LegalBasisForTransfersEnum(str, Enum):
-    """The model for describing the legal basis under which data is transferred"""
+    """
+    The model for describing the legal basis under which data is transferred
+
+    We currently do _not_ enforce this enum on the `legal_basis_for_transfers`
+    field, because the set of allowable values seems to be changing frequently 
+    and without clear notice in upstream, public data sources.
+    """
 
     ADEQUACY_DECISION = "Adequacy Decision"
     SCCS = "SCCs"

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -230,6 +230,7 @@ class LegalBasisForTransfersEnum(str, Enum):
     ADEQUACY_DECISION = "Adequacy Decision"
     SCCS = "SCCs"
     BCRS = "BCRs"
+    SUPPLEMENTARY_MEASURES = "Supplementary Measures"
     OTHER = "Other"
 
 
@@ -1181,7 +1182,7 @@ class System(FidesModel):
         default=False,
         description="Whether this system transfers data to other countries or international organizations.",
     )
-    legal_basis_for_transfers: List[LegalBasisForTransfersEnum] = Field(
+    legal_basis_for_transfers: List[str] = Field(
         default_factory=list,
         description="The legal basis (or bases) under which the data is transferred.",
     )

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -404,7 +404,7 @@ class TestSystem:
             uses_profiling=True,
             legal_basis_for_profiling=["Explicit consent", "Contract"],
             does_international_transfers=True,
-            legal_basis_for_transfers=["Adequacy Decision", "SCCs"],
+            legal_basis_for_transfers=["Adequacy Decision", "SCCs", "New legal basis"],
             requires_data_protection_assessments=True,
             dpa_location="www.example.com/dpa_location",
             privacy_policy="https://vdx.tv/privacy/",


### PR DESCRIPTION
Closes N/A

### Description Of Changes

We keep encountering new values for system legal basis for transfers. For now, remove the enum and allow this value to be any string.  We'll rely on some frontend transformations to try to keep this in line, but this will avoid changes across multiple backend repos in the future.


### Code Changes

* [ ] legal basis for transfers changed to a list of strings

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
