### PR TITLE
Add Collections Skip Processing Flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,20 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fideslang/compare/2.0.2...main)
+## [Unreleased](https://github.com/ethyca/fideslang/compare/2.0.3...main)
+
+
+### Changed
+
+- Add Collection > Fides Meta > Skip Processing Flag to skip collections in DSR processing [#165](https://github.com/ethyca/fideslang/pull/165)
+
+
+## [2.0.3](https://github.com/ethyca/fideslang/compare/2.0.2...2.0.3)
+
+### Changed
+
+- Relax system legal basis for transfer fields [#162](https://github.com/ethyca/fideslang/pull/162)
+
 
 ## [2.0.2](https://github.com/ethyca/fideslang/compare/2.0.1...2.0.2)
 
@@ -38,6 +51,14 @@ The types of changes are:
 
 - Updated the Data Categories and Data Uses to support GVL [#144](https://github.com/ethyca/fideslang/pull/144)
 - Add version metadata to the default taxonomy items [#147](https://github.com/ethyca/fideslang/pull/147)
+
+
+## [1.4.6 (Hotfix)](https://github.com/ethyca/fideslang/compare/1.4.5...1.4.6)
+
+### Changed
+
+- Relax system legal basis for transfer fields [#162](https://github.com/ethyca/fideslang/pull/162)
+
 
 ## [1.4.5 (Hotfix)](https://github.com/ethyca/fideslang/compare/1.4.4...1.4.5)
 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -604,6 +604,7 @@ class CollectionMeta(BaseModel):
     """Collection-level specific annotations used for query traversal"""
 
     after: Optional[List[FidesCollectionKey]]
+    skip_processing: Optional[bool] = False
 
 
 class DatasetCollection(FidesopsMetaBackwardsCompat):

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -540,6 +540,35 @@ class TestDataset:
                 }
             )
 
+    def test_dataset_collection_skip_processing(self):
+        collection = DatasetCollection(
+            name="dataset_collection_1",
+            data_qualifier="data_collection_data_qualifier_1",
+            data_categories=["dataset_collection_data_category_1"],
+            fields=[],
+        )
+        assert not collection.fides_meta
+
+        collection = DatasetCollection(
+            name="dataset_collection_1",
+            data_qualifier="data_collection_data_qualifier_1",
+            data_categories=["dataset_collection_data_category_1"],
+            fides_meta={"after": ["third_dataset.blue_collection"]},
+            fields=[],
+        )
+
+        assert collection.fides_meta.skip_processing is False
+
+        collection = DatasetCollection(
+            name="dataset_collection_1",
+            data_qualifier="data_collection_data_qualifier_1",
+            data_categories=["dataset_collection_data_category_1"],
+            fides_meta={"skip_processing": True},
+            fields=[],
+        )
+
+        assert collection.fides_meta.skip_processing
+
 
 class TestDataUse:
     def test_minimal_data_use(self):


### PR DESCRIPTION
Partially closes  https://github.com/ethyca/fidesplus/issues/1059


### Description Of Changes

Add an optional `skip_processing` flag under Collection > Fides Meta for use in skipping that collection as part of DSR processing.

### Code Changes

* [ ] CollectionMeta has an optional `skip_processing` flag

### Steps to Confirm

* [ ] See in action here! https://github.com/ethyca/fidesplus/issues/1059

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
