### PR TITLE
remove mistaken trailing dot from some data categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The types of changes are:
 
 ### Fixed
 
-- Removed mistaken trailing `.` on some data cateogry `name`s in the default taxonomy [#169](https://github.com/ethyca/fideslang/pull/169)
+- Removed mistaken trailing `.` on some data category `name`s in the default taxonomy [#169](https://github.com/ethyca/fideslang/pull/169)
 
 
 ## [2.1.0](https://github.com/ethyca/fideslang/compare/2.0.4...2.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/2.1.0...main)
 
+### Fixed
+
+- Removed mistaken trailing `.` on some data cateogry `name`s in the default taxonomy [#169](https://github.com/ethyca/fideslang/pull/169)
+
 
 ## [2.1.0](https://github.com/ethyca/fideslang/compare/2.0.4...2.1.0)
 

--- a/data_files/data_categories.csv
+++ b/data_files/data_categories.csv
@@ -4,8 +4,8 @@ system,True,System Data,default_organization,data_category,,,2.0.0,,"Data unique
 system.authentication,True,Authentication Data,default_organization,system,,,2.0.0,,Data used to manage access to the system.
 system.operations,True,Operations Data,default_organization,system,,,2.0.0,,Data used for system operations.
 user,True,User Data,default_organization,data_category,,,2.0.0,,"Data related to the user of the system, either provided directly or derived based on their usage."
-user.account,True,Account Information.,default_organization,user,,,2.0.0,,Account creation or registration information.
-user.authorization,True,Authorization Information.,default_organization,user,,,2.0.0,,Scope of permissions and access to a system.
+user.account,True,Account Information,default_organization,user,,,2.0.0,,Account creation or registration information.
+user.authorization,True,Authorization Information,default_organization,user,,,2.0.0,,Scope of permissions and access to a system.
 user.behavior,True,Observed Behavior,default_organization,user,,,2.0.0,,Behavioral data about the subject.
 user.biometric,True,Biometric Data,default_organization,user,,,2.0.0,,Encoded characteristics provided by a user.
 user.childrens,True,Children's Data,default_organization,user,,,2.0.0,,Data relating to children.
@@ -30,7 +30,7 @@ user.privacy_preferences,True,Privacy Preferences,default_organization,user,,,2.
 user.job_title,True,Job Title,default_organization,user,,,2.0.0,,Professional data.
 user.account.settings,True,Account Settings,default_organization,user.account,,,2.0.0,,Account preferences and settings.
 user.account.username,True,Account Username,default_organization,user.account,,,2.0.0,,Username associated with account.
-user.authorization.credentials,True,Account password.,default_organization,user.authorization,,,2.0.0,,Authentication credentials to a system.
+user.authorization.credentials,True,Account password,default_organization,user.authorization,,,2.0.0,,Authentication credentials to a system.
 user.authorization.biometric,True,Biometric Credentials,default_organization,user.authorization,,,2.0.0,,Credentials for system authentication.
 user.authorization.password,True,Password,default_organization,user.authorization,,,2.0.0,,Password for system authentication.
 user.behavior.browsing_history,True,Browsing History,default_organization,user.behavior,,,2.0.0,,Content browsing history of a user.

--- a/data_files/data_categories.json
+++ b/data_files/data_categories.json
@@ -56,7 +56,7 @@
             "fides_key": "user.account",
             "organization_fides_key": "default_organization",
             "tags": null,
-            "name": "Account Information.",
+            "name": "Account Information",
             "description": "Account creation or registration information.",
             "parent_key": "user"
         },
@@ -68,7 +68,7 @@
             "fides_key": "user.authorization",
             "organization_fides_key": "default_organization",
             "tags": null,
-            "name": "Authorization Information.",
+            "name": "Authorization Information",
             "description": "Scope of permissions and access to a system.",
             "parent_key": "user"
         },
@@ -368,7 +368,7 @@
             "fides_key": "user.authorization.credentials",
             "organization_fides_key": "default_organization",
             "tags": null,
-            "name": "Account password.",
+            "name": "Account password",
             "description": "Authentication credentials to a system.",
             "parent_key": "user.authorization"
         },

--- a/data_files/data_categories.yml
+++ b/data_files/data_categories.yml
@@ -47,7 +47,7 @@ data_category:
   fides_key: user.account
   organization_fides_key: default_organization
   tags: null
-  name: Account Information.
+  name: Account Information
   description: Account creation or registration information.
   parent_key: user
 - version_added: 2.0.0
@@ -307,7 +307,7 @@ data_category:
   fides_key: user.authorization.credentials
   organization_fides_key: default_organization
   tags: null
-  name: Account password.
+  name: Account password
   description: Authentication credentials to a system.
   parent_key: user.authorization
 - version_added: 2.0.0

--- a/mkdocs/docs/csv/data_categories.csv
+++ b/mkdocs/docs/csv/data_categories.csv
@@ -4,8 +4,8 @@ system,True,System Data,default_organization,data_category,,,2.0.0,,"Data unique
 system.authentication,True,Authentication Data,default_organization,system,,,2.0.0,,Data used to manage access to the system.
 system.operations,True,Operations Data,default_organization,system,,,2.0.0,,Data used for system operations.
 user,True,User Data,default_organization,data_category,,,2.0.0,,"Data related to the user of the system, either provided directly or derived based on their usage."
-user.account,True,Account Information.,default_organization,user,,,2.0.0,,Account creation or registration information.
-user.authorization,True,Authorization Information.,default_organization,user,,,2.0.0,,Scope of permissions and access to a system.
+user.account,True,Account Information,default_organization,user,,,2.0.0,,Account creation or registration information.
+user.authorization,True,Authorization Information,default_organization,user,,,2.0.0,,Scope of permissions and access to a system.
 user.behavior,True,Observed Behavior,default_organization,user,,,2.0.0,,Behavioral data about the subject.
 user.biometric,True,Biometric Data,default_organization,user,,,2.0.0,,Encoded characteristics provided by a user.
 user.childrens,True,Children's Data,default_organization,user,,,2.0.0,,Data relating to children.
@@ -30,7 +30,7 @@ user.privacy_preferences,True,Privacy Preferences,default_organization,user,,,2.
 user.job_title,True,Job Title,default_organization,user,,,2.0.0,,Professional data.
 user.account.settings,True,Account Settings,default_organization,user.account,,,2.0.0,,Account preferences and settings.
 user.account.username,True,Account Username,default_organization,user.account,,,2.0.0,,Username associated with account.
-user.authorization.credentials,True,Account password.,default_organization,user.authorization,,,2.0.0,,Authentication credentials to a system.
+user.authorization.credentials,True,Account password,default_organization,user.authorization,,,2.0.0,,Authentication credentials to a system.
 user.authorization.biometric,True,Biometric Credentials,default_organization,user.authorization,,,2.0.0,,Credentials for system authentication.
 user.authorization.password,True,Password,default_organization,user.authorization,,,2.0.0,,Password for system authentication.
 user.behavior.browsing_history,True,Browsing History,default_organization,user.behavior,,,2.0.0,,Content browsing history of a user.

--- a/src/fideslang/default_taxonomy/data_categories.py
+++ b/src/fideslang/default_taxonomy/data_categories.py
@@ -16,7 +16,7 @@ DEFAULT_DATA_CATEGORIES = [
     # user.account
     default_category_factory(
         fides_key="user.account",
-        name="Account Information.",
+        name="Account Information",
         description="Account creation or registration information.",
         parent_key="user",
     ),
@@ -37,13 +37,13 @@ DEFAULT_DATA_CATEGORIES = [
     ######################
     default_category_factory(
         fides_key="user.authorization",
-        name="Authorization Information.",
+        name="Authorization Information",
         description="Scope of permissions and access to a system.",
         parent_key="user",
     ),
     default_category_factory(
         fides_key="user.authorization.credentials",
-        name="Account password.",
+        name="Account password",
         description="Authentication credentials to a system.",
         parent_key="user.authorization",
     ),


### PR DESCRIPTION
Closes n/a

### Description Of Changes

@allisonking noticed some trailing `.`s in `name`s of a few data categories in the default taxonomy. this is a minor hygienic issue, but may as well clean it up sooner rather than later.

Note that i don't _think_ with just this change we'll update the `name` displayed for these categories on existing `fides` instances that are upgrading. we could write a migration to update that metadata, but feels like it's probably overkill...i think?


### Code Changes

* [ ] update `name` field on offending entries in the default taxonomy and any associated references (don't think i missed any?!)

### Steps to Confirm

* [ ] CI passing should be good enough?

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
