### PR TITLE
Restore personalize.profiling

### DIFF
--- a/src/fideslang/default_taxonomy/data_uses.py
+++ b/src/fideslang/default_taxonomy/data_uses.py
@@ -306,6 +306,14 @@ DEFAULT_DATA_USES = [
         parent_key="personalize",
     ),
     default_use_factory(
+        fides_key="personalize.profiling",
+        name="Personalized Profiling",
+        description="Creates profiles for the purpose of serving content.",
+        parent_key="personalize",
+        version_deprecated="2.1.1",
+        replaced_by="personalize.content.profiling",
+    ),
+    default_use_factory(
         fides_key="personalize.content.limited",
         name="Limited Content Personalization",
         description="Uses limited data for the purpose of serving content.",

--- a/tests/fideslang/test_default_taxonomy.py
+++ b/tests/fideslang/test_default_taxonomy.py
@@ -7,7 +7,7 @@ from fideslang.default_taxonomy import DEFAULT_TAXONOMY
 
 taxonomy_counts = {
     "data_category": 85,
-    "data_use": 54,
+    "data_use": 55,
     "data_subject": 15,
     "data_qualifier": 5,
 }
@@ -46,7 +46,7 @@ class TestDefaultTaxonomy:
 
     @pytest.mark.parametrize("data_type", taxonomy_counts.keys())
     def test_description_uniqueness(self, data_type: str) -> None:
-        keys = [x.description for x in getattr(DEFAULT_TAXONOMY, data_type)]
+        keys = [x.description for x in getattr(DEFAULT_TAXONOMY, data_type) if not x.version_deprecated]
         duplicate_keys = {
             key: value for key, value in Counter(keys).items() if value > 1
         }


### PR DESCRIPTION
Partially closes https://github.com/ethyca/fides/issues/4226

This assumes a 2.1.1 release - 

### Description Of Changes

Update from https://github.com/ethyca/fideslang/pull/171

Restores `personalize.profiling`.  Marks as deprecated instead of deleting altogether.

### Code Changes

* [ ] _list your code changes here_

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
