### PR TITLE
update `flexible_legal_basis_for_profiling` boolean field to be optional

### DIFF
--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -991,9 +991,8 @@ class PrivacyDeclaration(BaseModel):
     features: List[str] = Field(
         default_factory=list, description="The features of processing personal data."
     )
-    flexible_legal_basis_for_processing: bool = Field(
+    flexible_legal_basis_for_processing: Optional[bool] = Field(
         description="Whether the legal basis for processing is 'flexible' (i.e. can be overridden in a privacy notice) for this declaration.",
-        default=False,
     )
     legal_basis_for_processing: Optional[LegalBasisForProcessingEnum] = Field(
         description="The legal basis under which personal data is processed for this purpose."


### PR DESCRIPTION
Closes n/a

### Description Of Changes

as @NevilleS [pointed out in the original PR](https://github.com/ethyca/fideslang/pull/177#discussion_r1350954092) just merged that added this field, we should have made the `flexible_legal_basis_for_profiling` field an `Optional[bool]` field on our `PrivacyDeclaration` model.

I'd thought this was a nitpick that could be ignored, but on further thought, i think this could have a legitimate functional impact! basically, for non-GVL based privacy declarations, we don't really want to specify whether or not they have a flexible legal basis. for GVL-based privacy declarations, we want to specify whether the legal basis is flexible or not.

i've tested this change with fides and the API/db layer, and things seem to work as expected. if the API request doesn't specify the field, it's left null in the db. if the API request does specify either true or false, the corresponding value gets persisted to the db 👍 


### Code Changes

* [ ] make the `PrivacyDeclaration.flexible_legal_basis_for_processing` model field an `Optional[bool]` with no default, i.e. defaults to `None`/null

### Steps to Confirm

* [ ] tested fides API/db integration by using the fideslang alpha package based on this branch

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
