### PR TITLE
System Level Cookies

### DIFF
--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -1245,7 +1245,7 @@ class System(FidesModel):
     legitimate_interest_disclosure_url: Optional[AnyUrl] = Field(
         description="A URL that points to the system's publicly accessible legitimate interest disclosure."
     )
-    system_level_cookies: Optional[List[Cookies]] = Field(
+    cookies: Optional[List[Cookies]] = Field(
         description="System-level cookies unassociated with a data use to deliver services and functionality",
     )
 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -1245,6 +1245,9 @@ class System(FidesModel):
     legitimate_interest_disclosure_url: Optional[AnyUrl] = Field(
         description="A URL that points to the system's publicly accessible legitimate interest disclosure."
     )
+    system_level_cookies: Optional[List[Cookies]] = Field(
+        description="System-level cookies unassociated with a data use to deliver services and functionality",
+    )
 
     _sort_privacy_declarations: classmethod = validator(
         "privacy_declarations", allow_reuse=True

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -414,14 +414,13 @@ class TestSystem:
             responsibility=[DataResponsibilityTitle.CONTROLLER],
             dpo="privacyofficertest@vdx.tv",
             data_security_practices=None,
-            cookies=[{"name": "test_cookie"}],
             cookie_max_age_seconds="31536000",
             uses_cookies=True,
             cookie_refresh=True,
             uses_non_cookie_access=True,
             legitimate_interest_disclosure_url="http://www.example.com/legitimate_interest_disclosure",
             flexible_legal_basis_for_processing=True,
-            system_level_cookies=[
+            cookies=[
                 {
                     "name": "COOKIE_ID_EXAMPLE",
                     "path": "/",

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -421,6 +421,13 @@ class TestSystem:
             uses_non_cookie_access=True,
             legitimate_interest_disclosure_url="http://www.example.com/legitimate_interest_disclosure",
             flexible_legal_basis_for_processing=True,
+            system_level_cookies=[
+                {
+                    "name": "COOKIE_ID_EXAMPLE",
+                    "path": "/",
+                    "domain": "example.com/cookie",
+                }
+            ],
         )
 
     @mark.parametrize(


### PR DESCRIPTION
Partially closes https://ethyca.atlassian.net/browse/PROD-1310

### Description Of Changes

Add a new fideslang System property to support setting Cookies at the System level only that are unassociated with a data use.



### Code Changes

* [ ] Adds new `System.cookies` property.  Note we already had this on the `SystemResponse` schema in Fides, where its meaning was cookies either on the PrivacyDeclaration or the System.  We are changing the meaning of `System.cookies` here, so they are only cookies at the System level.  If you want to attach a Cookie to a PrivacyDeclaration attach it there directly.

### Steps to Confirm

* [ ] _list any manual steps taken to confirm the changes_

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
