### PR TITLE
support `previous_vendor_id` attribute on System model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,18 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fideslang/compare/2.2.0...main)
+## [Unreleased](https://github.com/ethyca/fideslang/compare/2.2.1...main)
+
+## [2.2.1](https://github.com/ethyca/fideslang/compare/2.2.0...2.2.1)
+
+### Added 
+
+- Added a `System.cookies` property to support `Cookie` records explicitly associated with a `System` generally [#181](https://github.com/ethyca/fideslang/pull/181)
+- Added a `System.previous_vendor_id` property to support to associate a `System` record with a "deprecated" vendor record [#182](https://github.com/ethyca/fideslang/pull/182)
 
 ## [2.2.0](https://github.com/ethyca/fideslang/compare/2.1.0...2.2.0)
 
-### Added 
+### Added
 
 - Added support for new TCF-based `System` fields [#173](https://github.com/ethyca/fideslang/pull/173)
 - Added support for `PrivacyDeclaration.flexible_legal_basis_for_profiling` field [#177](https://github.com/ethyca/fideslang/pull/177) [#178](https://github.com/ethyca/fideslang/pull/178)

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -1165,6 +1165,9 @@ class System(FidesModel):
     vendor_id: Optional[str] = Field(
         description="The unique identifier for the vendor that's associated with this system."
     )
+    previous_vendor_id: Optional[str] = Field(
+        description="If specified, the unique identifier for the vendor that was previously associated with this system."
+    )
     dataset_references: List[FidesKey] = Field(
         default_factory=list,
         description="Referenced Dataset fides keys used by the system.",

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -92,6 +92,10 @@ class TestPrivacyDeclaration:
 
 
 class TestSystem:
+    # TODO: these tests are not effectively evaluating whether the provided constructor args
+    # are actually supported, because our `System` model does not prohibit "extra" fields.
+    # We need to update these tests to assert that the provided args are actually being set
+    # as attributes on the System instance that's instantiated.
     def test_system_valid(self) -> None:
         assert System(
             description="Test Policy",
@@ -390,13 +394,14 @@ class TestSystem:
                     data_shared_with_third_parties=True,
                     third_parties="advertising; marketing",
                     shared_categories=[],
+                    flexible_legal_basis_for_processing=True,
                     cookies=[
                         {"name": "ANON_ID", "path": "/", "domain": "tribalfusion.com"}
                     ],
                 )
             ],
             third_country_transfers=["ARM"],
-            vendor_id="1",
+            vendor_id="gvl.1",
             dataset_references=["test_fides_key_dataset"],
             processes_personal_data=True,
             exempt_from_privacy_regulations=False,
@@ -419,7 +424,7 @@ class TestSystem:
             cookie_refresh=True,
             uses_non_cookie_access=True,
             legitimate_interest_disclosure_url="http://www.example.com/legitimate_interest_disclosure",
-            flexible_legal_basis_for_processing=True,
+            previous_vendor_id="gacp.10",
             cookies=[
                 {
                     "name": "COOKIE_ID_EXAMPLE",


### PR DESCRIPTION
part of https://ethyca.atlassian.net/browse/PROD-1296

### Description Of Changes

Adds a new, optional `previous_vendor_id` attribute/field to the `System` model. This field will help us indicate whether a given vendor record (or a system based on that vendor) used to be represented by a different vendor record, e.g. if a google AC vendor transitions to a GVL vendor, as is expected to happen somewhat regularly.


### Code Changes

* [x] add `previous_vendor_id` attribute to `System` model
* [x] some test cleanup, add a TODO comment since i realized some of our model tests aren't really effective...

### Steps to Confirm

* [x] will test out by publishing an alpha tag and using this in Compass webservice code to ensure it can support this new column on Compass data. UPDATE: tested with 2.2.1a0 alpha package, works well 👍 

### Pre-Merge Checklist

* [x] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [x] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [x] Update `CHANGELOG.md`
