### PR TITLE
Flexible Legal Basis = True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/2.2.1...main)
 
+### Added
+
+- Give Flexible Legal Basis a default of True [#184](https://github.com/ethyca/fideslang/pull/184)
+
 ## [2.2.1](https://github.com/ethyca/fideslang/compare/2.2.0...2.2.1)
 
 ### Added 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -991,8 +991,9 @@ class PrivacyDeclaration(BaseModel):
     features: List[str] = Field(
         default_factory=list, description="The features of processing personal data."
     )
-    flexible_legal_basis_for_processing: Optional[bool] = Field(
+    flexible_legal_basis_for_processing: bool = Field(
         description="Whether the legal basis for processing is 'flexible' (i.e. can be overridden in a privacy notice) for this declaration.",
+        default=True,
     )
     legal_basis_for_processing: Optional[LegalBasisForProcessingEnum] = Field(
         description="The legal basis under which personal data is processed for this purpose."

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -434,6 +434,17 @@ class TestSystem:
             ],
         )
 
+    def test_flexible_legal_basis_default(self):
+        pd = PrivacyDeclaration(
+            data_categories=[],
+            data_qualifier="aggregated_data",
+            data_subjects=[],
+            data_use="provide",
+            ingress=["user"],
+            name="declaration-name",
+        )
+        assert pd.flexible_legal_basis_for_processing
+
     @mark.parametrize(
         "deprecated_field,value",
         [


### PR DESCRIPTION
Closes #PROD-1264

### Description Of Changes

Update fideslang defaults to match what should happen when a user creates a System outside of Compass, as there shouldn't be limitations by default.

### Code Changes

Update flexible legal basis for processing to make it non-optional with a True default.

### Steps to Confirm

* [ ] See this in action here: https://github.com/ethyca/fides/pull/4434

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
