### PR TITLE
HA-399 prereq: deprecate cookies

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -32,7 +32,7 @@ jobs:
           tags: ${{ env.IMAGE }}
 
       - name: Upload fideslang container
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.CONTAINER }}
           path: /tmp/${{ env.CONTAINER }}.tar

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -93,9 +93,9 @@ jobs:
   Pytest-Matrix:
     strategy:
       matrix:
-        python_version: ["3.8", "3.9", "3.10", "3.11"]
-        pydantic_version: ["1.8.2", "1.9.2", "1.10.9"]
-        pyyaml_version: ["5.4.1", "6.0"]
+        python_version: ["3.9", "3.10", "3.11"]
+        pydantic_version: ["2.3.0", "2.4.2",  "2.5.3", "2.6.4", "2.7.1"]
+        pyyaml_version: ["5.4.1", "6.0.1"]
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.1...main)
 
+### Changed
+
+- Upgrades Pydantic for V2 support and removes support for Pydantic V1 [#11](https://github.com/ethyca/fideslang/pull/11)
+- Removes Python 3.8 from supported versions [#11](https://github.com/ethyca/fideslang/pull/11)
+- 
 ## [3.0.1](https://github.com/ethyca/fideslang/compare/3.0.0...3.0.1)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.8...main)
+## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.9...main)
+
+## [3.0.9](https://github.com/ethyca/fideslang/compare/3.0.8...3.0.9)
+
+### Added
 
 - Add field-level masking strategy overrides [#23](https://github.com/ethyca/fideslang/pull/23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.5...main)
+## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.6...main)
+
+
+
+## [3.0.6](https://github.com/ethyca/fideslang/compare/3.0.5...3.0.6)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,16 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.1...main)
+## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.2...main)
+
+
+## [3.0.2](https://github.com/ethyca/fideslang/compare/3.0.1...3.0.2)
 
 ### Changed
 
 - Upgrades Pydantic for V2 support and removes support for Pydantic V1 [#11](https://github.com/ethyca/fideslang/pull/11)
 - Removes Python 3.8 from supported versions [#11](https://github.com/ethyca/fideslang/pull/11)
-- 
+
 ## [3.0.1](https://github.com/ethyca/fideslang/compare/3.0.0...3.0.1)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.5...main)
 
+### Changed
+
+- Add collection-level masking strategy overrides and support specifying one collection to be erased after another [#17](https://github.com/ethyca/fideslang/pull/17)
+
+
 ## [3.0.5](https://github.com/ethyca/fideslang/compare/3.0.4...3.0.5)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The types of changes are:
 - `Security` in case of vulnerabilities.
 
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.3...main)
+- Adds mappings and new data use for special purposes 3 [#15](https://github.com/ethyca/fideslang/pull/15)
 
 
 ## [3.0.3](https://github.com/ethyca/fideslang/compare/3.0.2...3.0.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,14 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.3...main)
+## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.4...main)
+
+
+## [3.0.4](https://github.com/ethyca/fideslang/compare/3.0.3...3.0.4)
+
+### Added
+
+- Adds mappings and new data use for special purposes 3 [#15](https://github.com/ethyca/fideslang/pull/15)
 
 
 ## [3.0.3](https://github.com/ethyca/fideslang/compare/3.0.2...3.0.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,13 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.4...main)
+## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.5...main)
 
+## [3.0.5](https://github.com/ethyca/fideslang/compare/3.0.4...3.0.5)
+
+### Added
+
+- Adds namespace field to dataset fides_meta [#18](https://github.com/ethyca/fideslang/pull/18)
 
 ## [3.0.4](https://github.com/ethyca/fideslang/compare/3.0.3...3.0.4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,13 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.3...main)
+## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.4...main)
+
+
+## [3.0.4](https://github.com/ethyca/fideslang/compare/3.0.3...3.0.4)
+
+### Added
+
 - Adds mappings and new data use for special purposes 3 [#15](https://github.com/ethyca/fideslang/pull/15)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.8...main)
 
+- Add field-level masking strategy overrides [#23](https://github.com/ethyca/fideslang/pull/23)
 
 ## [3.0.8](https://github.com/ethyca/fideslang/compare/3.0.7...3.0.8)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,14 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.7...main)
+## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.8...main)
+
+
+## [3.0.8](https://github.com/ethyca/fideslang/compare/3.0.7...3.0.8)
 
 ### Changed
 
 - Remove stipulation that sub fields (Field) of a Field object cannot have data categories assigned [#22](https://github.com/ethyca/fideslang/pull/22)
-
 
 ## [3.0.7](https://github.com/ethyca/fideslang/compare/3.0.6...3.0.7)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.2...main)
+## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.3...main)
+
+
+## [3.0.3](https://github.com/ethyca/fideslang/compare/3.0.2...3.0.3)
 - Add custom_request_field to FidesMeta [#13](https://github.com/ethyca/fideslang/pull/13)
 
 ## [3.0.2](https://github.com/ethyca/fideslang/compare/3.0.1...3.0.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.9...main)
 
+### Deprecated
+- Deprecated `Cookies` model and `.cookies` property on `System` and `PrivacyDeclaration` [#198](https://github.com/IABTechLab/fideslang/pull/198)
+
 ## [3.0.9](https://github.com/ethyca/fideslang/compare/3.0.8...3.0.9)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The types of changes are:
 - `Security` in case of vulnerabilities.
 
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.2...main)
-
+- Add custom_request_field to FidesMeta [#13](https://github.com/ethyca/fideslang/pull/13)
 
 ## [3.0.2](https://github.com/ethyca/fideslang/compare/3.0.1...3.0.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,14 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.6...main)
+## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.7...main)
 
+
+## [3.0.7](https://github.com/ethyca/fideslang/compare/3.0.6...3.0.7)
+
+### Added
+
+- Add a loosely-typed `partitioning` field to the `DatasetCollection.fides_meta` structure to support flexible database table partitioning specifications [#21](https://github.com/ethyca/fideslang/pull/21)
 
 
 ## [3.0.6](https://github.com/ethyca/fideslang/compare/3.0.5...3.0.6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.7...main)
 
+- Add field-level masking strategy overrides [#23](https://github.com/ethyca/fideslang/pull/23)
 
 ## [3.0.7](https://github.com/ethyca/fideslang/compare/3.0.6...3.0.7)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,13 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.0...main)
+## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.1...main)
+
+## [3.0.1](https://github.com/ethyca/fideslang/compare/3.0.0...3.0.1)
+
+### Added
+
+- Added a `vendor_deleted_date` field to the `System` model [#10](https://github.com/ethyca/fideslang/pull/10)
 
 ## [3.0.0](https://github.com/ethyca/fideslang/compare/2.2.2...3.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The types of changes are:
 
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.7...main)
 
+### Changed
+
+- Remove stipulation that sub fields (Field) of a Field object cannot have data categories assigned [#22](https://github.com/ethyca/fideslang/pull/22)
+
 
 ## [3.0.7](https://github.com/ethyca/fideslang/compare/3.0.6...3.0.7)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The types of changes are:
 ## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.9...main)
 
 ### Deprecated
-- Deprecated `Cookies` model and `.cookies` property on `System` and `PrivacyDeclaration` [#198](https://github.com/IABTechLab/fideslang/pull/198)
+- Deprecated `Cookies` model and `.cookies` property on `System` and `PrivacyDeclaration` [#199](https://github.com/IABTechLab/fideslang/pull/199)
 
 ## [3.0.9](https://github.com/ethyca/fideslang/compare/3.0.8...3.0.9)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,15 @@ The types of changes are:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.7...main)
+## [Unreleased](https://github.com/ethyca/fideslang/compare/3.0.8...main)
 
 - Add field-level masking strategy overrides [#23](https://github.com/ethyca/fideslang/pull/23)
+
+## [3.0.8](https://github.com/ethyca/fideslang/compare/3.0.7...3.0.8)
+
+### Changed
+
+- Remove stipulation that sub fields (Field) of a Field object cannot have data categories assigned [#22](https://github.com/ethyca/fideslang/pull/22)
 
 ## [3.0.7](https://github.com/ethyca/fideslang/compare/3.0.6...3.0.7)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-bullseye as base
+FROM python:3.9-slim-bullseye as base
 
 # Update pip in the base image since we'll use it everywhere
 RUN pip install -U pip

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,12 +1,12 @@
 black==23.3.0
-mypy==1.4.0
+mypy==1.10.0
 nox>=2023
 packaging>=22.0
-pre-commit==2.9.3
+pre-commit==3.7.1
 pylint==2.10.0
 pytest==7.3.1
 pytest-cov==2.11.1
 requests-mock==1.8.0
 setuptools>=64.0.2
 types-PyYAML
-xenon==0.7.3
+xenon==0.9.1

--- a/mkdocs/Dockerfile
+++ b/mkdocs/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-bullseye
+FROM python:3.9-slim-bullseye
 
 # Install auxiliary software
 RUN apt-get update

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,9 +3,10 @@ import nox
 nox.options.sessions = []
 nox.options.reuse_existing_virtualenvs = True
 
-TESTED_PYTHON_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
-TESTED_PYDANTIC_VERSIONS = ["1.8.2", "1.9.2", "1.10.9"]
-TESTED_PYYAML_VERSIONS = ["5.4.1", "6.0"]
+# These should match what is in the `pr_checks.yml` file for CI runs
+TESTED_PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
+TESTED_PYDANTIC_VERSIONS = ["2.3.0", "2.4.2",  "2.5.3", "2.6.4", "2.7.1"]
+TESTED_PYYAML_VERSIONS = ["5.4.1", "6.0.1"]
 
 
 def install_requirements(session: nox.Session) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,12 @@ name = "fideslang"
 description = "Fides Taxonomy Language"
 dynamic = ["dependencies", "version"]
 readme = "README.md"
-requires-python = ">=3.8, <4"
+requires-python = ">=3.9, <4"
 authors = [{ name = "Ethyca, Inc.", email = "fidesteam@ethyca.com" }]
 license = { text = "Apache License 2.0" }
 classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pydantic>=1.8.1,<1.11.0
+pydantic>=2.3.0,<=2.7.1
 pyyaml>=5,<7
 packaging>=20.0

--- a/src/fideslang/default_fixtures.py
+++ b/src/fideslang/default_fixtures.py
@@ -9,7 +9,6 @@ To update:
 2. Copy/Paste the JSON response below
 """
 
-
 COUNTRY_CODES = [
     {"name": "Afghanistan", "alpha3Code": "AFG"},
     {"name": "Åland Islands", "alpha3Code": "ALA"},

--- a/src/fideslang/default_taxonomy/__init__.py
+++ b/src/fideslang/default_taxonomy/__init__.py
@@ -7,8 +7,8 @@ from .data_subjects import DEFAULT_DATA_SUBJECTS
 from .data_uses import DEFAULT_DATA_USES
 from .organizations import DEFAULT_ORGANIZATIONS
 
-sort_data_types = (
-    lambda x: x.parent_key if hasattr(x, "parent_key") and x.parent_key else x.fides_key
+sort_data_types = lambda x: (
+    x.parent_key if hasattr(x, "parent_key") and x.parent_key else x.fides_key
 )
 
 DEFAULT_TAXONOMY = Taxonomy(

--- a/src/fideslang/default_taxonomy/data_uses.py
+++ b/src/fideslang/default_taxonomy/data_uses.py
@@ -180,6 +180,12 @@ DEFAULT_DATA_USES = [
         parent_key="functional",
     ),
     default_use_factory(
+        fides_key="functional.storage.privacy_preferences",
+        name="Local Data Storage for Privacy Preferences",
+        description="Stores or accesses privacy preferences information from the device as needed when using a product, service, application, or system",
+        parent_key="functional.storage",
+    ),
+    default_use_factory(
         fides_key="functional.service",
         name="Service",
         description="Functions relating to provided services, products, applications or systems.",

--- a/src/fideslang/default_taxonomy/utils.py
+++ b/src/fideslang/default_taxonomy/utils.py
@@ -18,5 +18,5 @@ def default_factory(taxonomy_class: CustomType, **kwargs: Dict) -> CustomType:
         # This is the version where we started tracking from, so
         # we use it as the default starting point.
         kwargs["version_added"] = "2.0.0"  # type: ignore[assignment]
-    item = taxonomy_class.parse_obj(kwargs)
+    item = taxonomy_class.model_validate(kwargs)
     return item

--- a/src/fideslang/gvl/__init__.py
+++ b/src/fideslang/gvl/__init__.py
@@ -50,16 +50,16 @@ def _load_data() -> None:
     ) as mapping_file:
         data = load(mapping_file)
         for raw_purpose in data["purposes"].values():
-            purpose = Purpose.parse_obj(raw_purpose)
-            mapped_purpose = MappedPurpose.parse_obj(raw_purpose)
+            purpose = Purpose.model_validate(raw_purpose)
+            mapped_purpose = MappedPurpose.model_validate(raw_purpose)
             GVL_PURPOSES[purpose.id] = purpose
             MAPPED_PURPOSES[mapped_purpose.id] = mapped_purpose
             for data_use in mapped_purpose.data_uses:
                 MAPPED_PURPOSES_BY_DATA_USE[data_use] = mapped_purpose
 
         for raw_special_purpose in data["specialPurposes"].values():
-            special_purpose = Purpose.parse_obj(raw_special_purpose)
-            mapped_special_purpose = MappedPurpose.parse_obj(raw_special_purpose)
+            special_purpose = Purpose.model_validate(raw_special_purpose)
+            mapped_special_purpose = MappedPurpose.model_validate(raw_special_purpose)
             GVL_SPECIAL_PURPOSES[special_purpose.id] = special_purpose
             MAPPED_SPECIAL_PURPOSES[mapped_special_purpose.id] = mapped_special_purpose
             for data_use in mapped_special_purpose.data_uses:
@@ -71,12 +71,12 @@ def _load_data() -> None:
         feature_data = load(feature_mapping_file)
 
         for raw_feature in feature_data["features"].values():
-            feature = Feature.parse_obj(raw_feature)
+            feature = Feature.model_validate(raw_feature)
             GVL_FEATURES[feature.id] = feature
             FEATURES_BY_NAME[feature.name] = feature
 
         for raw_special_feature in feature_data["specialFeatures"].values():
-            special_feature = Feature.parse_obj(raw_special_feature)
+            special_feature = Feature.model_validate(raw_special_feature)
             GVL_SPECIAL_FEATURES[special_feature.id] = special_feature
             FEATURES_BY_NAME[special_feature.name] = special_feature
 
@@ -86,8 +86,8 @@ def _load_data() -> None:
         data_category_data = load(data_category_mapping_file)
 
         for raw_data_category in data_category_data.values():
-            data_category = GVLDataCategory.parse_obj(raw_data_category)
-            mapped_data_category = MappedDataCategory.parse_obj(raw_data_category)
+            data_category = GVLDataCategory.model_validate(raw_data_category)
+            mapped_data_category = MappedDataCategory.model_validate(raw_data_category)
             GVL_DATA_CATEGORIES[data_category.id] = data_category
             MAPPED_GVL_DATA_CATEGORIES[mapped_data_category.id] = mapped_data_category
 

--- a/src/fideslang/gvl/__init__.py
+++ b/src/fideslang/gvl/__init__.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional
 
 from .models import Feature, GVLDataCategory, MappedDataCategory, MappedPurpose, Purpose
 
-### (Special) Purposes
+### Purposes & Special Purposes
 
 PURPOSE_MAPPING_FILE = join(
     dirname(__file__),
@@ -21,7 +21,7 @@ GVL_SPECIAL_PURPOSES: Dict[int, Purpose] = {}
 MAPPED_SPECIAL_PURPOSES: Dict[int, MappedPurpose] = {}
 MAPPED_PURPOSES_BY_DATA_USE: Dict[str, MappedPurpose] = {}
 
-### (Special) Features
+### Features & Special Features
 
 FEATURE_MAPPING_FILE = join(
     dirname(__file__),

--- a/src/fideslang/gvl/gvl_data_use_mapping.json
+++ b/src/fideslang/gvl/gvl_data_use_mapping.json
@@ -128,6 +128,15 @@
             "illustrations": [
                 "Clicking on a link in an article might normally send you to another page or part of the article. To achieve this, 1°) your browser sends a request to a server linked to the website, 2°) the server answers back (“here is the article you asked for”), using technical information automatically included in the request sent by your device, to properly display the information / images that are part of the article you asked for. Technically, such exchange of information is necessary to deliver the content that appears on your screen."
             ]
+        },
+        "3": {
+            "id": 3,
+            "name": "Save and communicate privacy choices",
+            "data_uses": ["functional.storage.privacy_preferences"],
+            "description": "The choices you make regarding the purposes and entities listed in this notice are saved and made available to those entities in the form of digital signals (such as a string of characters). This is necessary in order to enable both this service and those entities to respect such choices.",
+            "illustrations": [
+                "When you visit a website and are offered a choice between consenting to the use of profiles for personalised advertising or not consenting, the choice you make is saved and made available to advertising providers, so that advertising presented to you respects that choice."
+            ]
         }
     }
 }

--- a/src/fideslang/gvl/models.py
+++ b/src/fideslang/gvl/models.py
@@ -32,7 +32,8 @@ class MappedPurpose(Purpose):
 
 
 class Feature(BaseModel):
-    "Pydantic model for GVL feature records"
+    """Pydantic model for GVL feature records"""
+
     id: int = Field(description="Official GVL feature ID or special feature ID")
     name: str = Field(description="Name of the GVL feature or special feature.")
     description: str = Field(

--- a/src/fideslang/manifests.py
+++ b/src/fideslang/manifests.py
@@ -1,4 +1,5 @@
 """This module handles anything related to working with raw manifest files."""
+
 import glob
 from functools import reduce
 from typing import Dict, List, Set, Union

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Annotated, Dict, List, Optional, Union, Any
+from typing import Annotated, Dict, List, Optional, Union
 
 from packaging.version import InvalidVersion, Version
 from pydantic import (
@@ -69,13 +69,17 @@ class MaskingStrategies(str, Enum):
 
 
 class MaskingStrategyOverride(BaseModel):
-    """Overrides policy-level masking strategies."""
+    """Overrides policy-level masking strategies in collections."""
 
     strategy: MaskingStrategies
 
+
 class FieldMaskingStrategyOverride(BaseModel):
+    """Overrides policy-level masking strategies in fields."""
+
     strategy: str
-    configuration: Dict[str, Any]
+    configuration: Dict
+
 
 class FidesModel(BaseModel):
     """The base model for most top-level Fides objects."""

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -479,8 +479,6 @@ class DatasetField(DatasetFieldBase, FidesopsMetaBackwardsCompat):
         """Two validation checks for object fields:
         - If there are sub-fields specified, type should be either empty or 'object'
         """
-        if self.fields:
-            breakpoint()
         fields = self.fields
         declared_data_type = None
         field_name: str = self.name

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -470,7 +470,7 @@ class DatasetField(DatasetFieldBase, FidesopsMetaBackwardsCompat):
                 "The 'return_all_elements' attribute can only be specified on array fields."
             )
         return meta_values
-    
+
     @model_validator(mode="after")
     def validate_object_fields(
         self,
@@ -492,6 +492,8 @@ class DatasetField(DatasetFieldBase, FidesopsMetaBackwardsCompat):
                 raise ValueError(
                     f"The data type '{data_type}' on field '{field_name}' is not compatible with specified sub-fields. Convert to an 'object' field."
                 )
+
+        return self
 
 
 # this is required for the recursive reference in the pydantic model:

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -579,6 +579,7 @@ class DatasetMetadata(BaseModel):
 
     resource_id: Optional[str] = None
     after: Optional[List[FidesKey]] = None
+    namespace: Optional[Dict] = None
 
 
 class Dataset(FidesModel, FidesopsMetaBackwardsCompat):

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -523,6 +523,29 @@ def validate_fides_collection_key(value: str) -> str:
 FidesCollectionKey = Annotated[str, AfterValidator(validate_fides_collection_key)]
 
 
+class PartitionType(Enum):
+    RANGE = "range"
+    TIME = "time"
+
+
+class TimePartitionInterval(Enum):
+    HOUR = "hour"
+    DAY = "day"
+    MONTH = "month"
+    YEAR = "year"
+
+
+class PartitionSpecification(BaseModel):
+    """Defines partition spec for a collection"""
+
+    field: str  # the field that's partitioned
+    partition_type: PartitionType
+    start_value: Union[int, datetime]  # should also support some sort of NOW()
+    end_value: Union[int, datetime]  # should also support some sort of NOW()
+    interval: Union[int, TimePartitionInterval]
+    partitions_per_query: int = 1
+
+
 class CollectionMeta(BaseModel):
     """Collection-level specific annotations used for query traversal"""
 
@@ -530,6 +553,7 @@ class CollectionMeta(BaseModel):
     erase_after: Optional[List[FidesCollectionKey]] = None
     skip_processing: Optional[bool] = False
     masking_strategy_override: Optional[MaskingStrategyOverride] = None
+    partitioning: Optional[PartitionSpecification] = None
 
 
 class DatasetCollection(FidesopsMetaBackwardsCompat):

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -471,35 +471,6 @@ class DatasetField(DatasetFieldBase, FidesopsMetaBackwardsCompat):
             )
         return meta_values
 
-    @model_validator(mode="after")
-    def validate_object_fields(
-        self,
-        _: ValidationInfo,
-    ) -> DatasetField:
-        """Two validation checks for object fields:
-        - If there are sub-fields specified, type should be either empty or 'object'
-        - Additionally object fields cannot have data_categories.
-        """
-        fields = self.fields
-        declared_data_type = None
-        field_name: str = self.name
-
-        if self.fides_meta:
-            declared_data_type = self.fides_meta.data_type
-
-        if fields and declared_data_type:
-            data_type, _ = parse_data_type_string(declared_data_type)
-            if data_type != "object":
-                raise ValueError(
-                    f"The data type '{data_type}' on field '{field_name}' is not compatible with specified sub-fields. Convert to an 'object' field."
-                )
-
-        if (fields or declared_data_type == "object") and self.data_categories:
-            raise ValueError(
-                f"Object field '{field_name}' cannot have specified data_categories. Specify category on sub-field instead"
-            )
-        return self
-
 
 # this is required for the recursive reference in the pydantic model:
 DatasetField.model_rebuild()

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -489,7 +489,6 @@ class DatasetField(DatasetFieldBase, FidesopsMetaBackwardsCompat):
     ) -> DatasetField:
         """Two validation checks for object fields:
         - If there are sub-fields specified, type should be either empty or 'object'
-        - Additionally object fields cannot have data_categories.
         """
         fields = self.fields
         declared_data_type = None
@@ -505,10 +504,6 @@ class DatasetField(DatasetFieldBase, FidesopsMetaBackwardsCompat):
                     f"The data type '{data_type}' on field '{field_name}' is not compatible with specified sub-fields. Convert to an 'object' field."
                 )
 
-        if (fields or declared_data_type == "object") and self.data_categories:
-            raise ValueError(
-                f"Object field '{field_name}' cannot have specified data_categories. Specify category on sub-field instead"
-            )
         return self
 
 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Annotated, Dict, List, Optional, Union
+from typing import Annotated, Dict, List, Optional, Union, Any
 
 from packaging.version import InvalidVersion, Version
 from pydantic import (
@@ -69,9 +69,16 @@ class MaskingStrategies(str, Enum):
 
 
 class MaskingStrategyOverride(BaseModel):
-    """Overrides policy-level masking strategies."""
+    """Overrides collection-level masking strategies."""
 
     strategy: MaskingStrategies
+
+
+class FieldMaskingStrategyOverride(BaseModel):  # type: ignore[misc]
+    """Overrides field-level masking strategies."""
+
+    strategy: str
+    configuration: Optional[Dict[str, Any]] = {}  # type: ignore[misc]
 
 
 class FidesModel(BaseModel):
@@ -417,6 +424,10 @@ class FidesMeta(BaseModel):
     custom_request_field: Optional[str] = Field(
         default=None,
         description="Optionally specify that a field may be used as a custom request field in DSRs. The value is the name of the field in the DSR.",
+    )
+    masking_strategy_override: Optional[FieldMaskingStrategyOverride] = Field(
+        default=None,
+        description="Optionally specify a masking strategy override for this field.",
     )
 
     @field_validator("data_type")

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Annotated, Dict, List, Optional, Union
+from typing import Annotated, Dict, List, Optional, Union, Any
 
 from packaging.version import InvalidVersion, Version
 from pydantic import (
@@ -74,11 +74,11 @@ class MaskingStrategyOverride(BaseModel):
     strategy: MaskingStrategies
 
 
-class FieldMaskingStrategyOverride(BaseModel):
+class FieldMaskingStrategyOverride(BaseModel):  # type: ignore[misc]
     """Overrides field-level masking strategies."""
 
     strategy: str
-    configuration: Optional[Dict] = {}
+    configuration: Optional[Dict[str, Any]] = {}  # type: ignore[misc]
 
 
 class FidesModel(BaseModel):

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -69,13 +69,13 @@ class MaskingStrategies(str, Enum):
 
 
 class MaskingStrategyOverride(BaseModel):
-    """Overrides policy-level masking strategies in collections."""
+    """Overrides collection-level masking strategies."""
 
     strategy: MaskingStrategies
 
 
 class FieldMaskingStrategyOverride(BaseModel):
-    """Overrides policy-level masking strategies in fields."""
+    """Overrides field-level masking strategies."""
 
     strategy: str
     configuration: Dict

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from datetime import datetime
 from enum import Enum
 from typing import Annotated, Dict, List, Optional, Union, Any
+from warnings import warn
 
 from packaging.version import InvalidVersion, Version
 from pydantic import (
@@ -284,12 +285,23 @@ class DataCategory(FidesModel, DefaultModel):
 
 
 class Cookies(BaseModel):
-    """The Cookies resource model"""
+    """
+    DEPRECATED.
+    The Cookies resource model
+    """
 
     name: str
     path: Optional[str] = None
     domain: Optional[str] = None
     model_config = ConfigDict(from_attributes=True)
+
+    @model_validator(mode="after")
+    def validate_cookies(self, _: ValidationInfo) -> Cookies:
+        """
+        Validate that the `cookies` field is deprecated and warn that it should not be used.
+        """
+        warn("The 'cookies' field is deprecated and should not be used.")
+        return self
 
 
 class DataSubjectRights(BaseModel):
@@ -881,9 +893,21 @@ class PrivacyDeclaration(BaseModel):
     )
     cookies: Optional[List[Cookies]] = Field(
         default=None,
-        description="Cookies associated with this data use to deliver services and functionality",
+        description="DEPRECATED. Cookies associated with this data use to deliver services and functionality",
     )
     model_config = ConfigDict(from_attributes=True)
+
+    @field_validator("cookies")
+    @classmethod
+    def validate_cookies(
+        cls, value: Optional[List[Cookies]]
+    ) -> Optional[List[Cookies]]:
+        """
+        Validate that the `cookies` field is deprecated and warn that it should not be used.
+        """
+        if value is not None:
+            warn("The 'cookies' field is deprecated and should not be used.")
+        return value
 
 
 class SystemMetadata(BaseModel):
@@ -1133,6 +1157,18 @@ class System(FidesModel):
                         ], f"PrivacyDeclaration '{privacy_declaration.name}' defines {direction} with '{fides_key}' and is applied to the System '{system}', which does not itself define {direction} with that resource."
 
         return self
+
+    @field_validator("cookies")
+    @classmethod
+    def validate_cookies(
+        cls, value: Optional[List[Cookies]]
+    ) -> Optional[List[Cookies]]:
+        """
+        Validate that the `cookies` field is deprecated and warn that it should not be used.
+        """
+        if value is not None:
+            warn("The 'cookies' field is deprecated and should not be used.")
+        return value
 
     model_config = ConfigDict(use_enum_values=True)
 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -5,6 +5,7 @@ Contains all of the Fides resources modeled as Pydantic models.
 """
 from __future__ import annotations
 
+from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
@@ -945,6 +946,9 @@ class System(FidesModel):
     )
     previous_vendor_id: Optional[str] = Field(
         description="If specified, the unique identifier for the vendor that was previously associated with this system."
+    )
+    vendor_deleted_date: Optional[datetime] = Field(
+        description="The deleted date of the vendor that's associated with this system."
     )
     dataset_references: List[FidesKey] = Field(
         default_factory=list,

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -538,12 +538,6 @@ class TimePartitionInterval(Enum):
 class PartitionSpecification(BaseModel):
     """Defines partition spec for a collection"""
 
-    field: str  # the field that's partitioned
-    partition_type: PartitionType
-    start_value: Union[int, datetime]  # should also support some sort of NOW()
-    end_value: Union[int, datetime]  # should also support some sort of NOW()
-    interval: Union[int, TimePartitionInterval]
-    partitions_per_query: int = 1
     where_clauses: Optional[List[str]] = None
 
 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -421,7 +421,7 @@ class FidesMeta(BaseModel):
         default=None,
         description="Optionally specify that a field may be used as a custom request field in DSRs. The value is the name of the field in the DSR.",
     )
-    masking_strategy_override = Optional[FieldMaskingStrategyOverride] = Field(
+    masking_strategy_override: Optional[FieldMaskingStrategyOverride] = Field(
         default=None,
         description="Optionally specify a masking strategy override for this field.",
     )

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -78,7 +78,7 @@ class FieldMaskingStrategyOverride(BaseModel):
     """Overrides field-level masking strategies."""
 
     strategy: str
-    configuration: Dict
+    configuration: Optional[Dict] = {}
 
 
 class FidesModel(BaseModel):

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -18,7 +18,6 @@ from pydantic import (
     HttpUrl,
     PositiveInt,
     SerializeAsAny,
-    ValidationInfo,
     field_validator,
     model_validator,
 )
@@ -32,7 +31,6 @@ from fideslang.validation import (
     is_deprecated_if_replaced,
     matching_parent_key,
     no_self_reference,
-    parse_data_type_string,
     sort_list_objects_by_name,
     unique_items_in_list,
     valid_data_type,

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -544,6 +544,7 @@ class PartitionSpecification(BaseModel):
     end_value: Union[int, datetime]  # should also support some sort of NOW()
     interval: Union[int, TimePartitionInterval]
     partitions_per_query: int = 1
+    where_clauses: Optional[List[str]] = None
 
 
 class CollectionMeta(BaseModel):

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -531,6 +531,10 @@ class CollectionMeta(BaseModel):
     skip_processing: Optional[bool] = False
     masking_strategy_override: Optional[MaskingStrategyOverride] = None
 
+    # partitioning metadata is kept open-ended as it is an experimental feature -
+    # more strictly defined metadata structures will be supported in the future
+    partitioning: Optional[Dict] = None
+
 
 class DatasetCollection(FidesopsMetaBackwardsCompat):
     """

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -523,22 +523,20 @@ def validate_fides_collection_key(value: str) -> str:
 FidesCollectionKey = Annotated[str, AfterValidator(validate_fides_collection_key)]
 
 
-class PartitionType(Enum):
-    RANGE = "range"
-    TIME = "time"
+class UserDefinedPartitionWindow(BaseModel):
+    """Defines a user-defined partition window"""
 
-
-class TimePartitionInterval(Enum):
-    HOUR = "hour"
-    DAY = "day"
-    MONTH = "month"
-    YEAR = "year"
+    start: str
+    end: str
+    start_inclusive: bool = True
+    end_inclusive: bool = True
 
 
 class PartitionSpecification(BaseModel):
     """Defines partition spec for a collection"""
 
-    where_clauses: Optional[List[str]] = None
+    field: str
+    windows: Optional[List[UserDefinedPartitionWindow]] = None
 
 
 class CollectionMeta(BaseModel):

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -523,22 +523,6 @@ def validate_fides_collection_key(value: str) -> str:
 FidesCollectionKey = Annotated[str, AfterValidator(validate_fides_collection_key)]
 
 
-class UserDefinedPartitionWindow(BaseModel):
-    """Defines a user-defined partition window"""
-
-    start: str
-    end: str
-    start_inclusive: bool = True
-    end_inclusive: bool = True
-
-
-class PartitionSpecification(BaseModel):
-    """Defines partition spec for a collection"""
-
-    field: str
-    windows: Optional[List[UserDefinedPartitionWindow]] = None
-
-
 class CollectionMeta(BaseModel):
     """Collection-level specific annotations used for query traversal"""
 
@@ -546,7 +530,10 @@ class CollectionMeta(BaseModel):
     erase_after: Optional[List[FidesCollectionKey]] = None
     skip_processing: Optional[bool] = False
     masking_strategy_override: Optional[MaskingStrategyOverride] = None
-    partitioning: Optional[PartitionSpecification] = None
+
+    # partitioning metadata is kept open-ended as it is an experimental feature -
+    # more strictly defined metadata structures will be supported in the future
+    partitioning: Optional[Dict] = None
 
 
 class DatasetCollection(FidesopsMetaBackwardsCompat):

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -62,6 +62,18 @@ meta_field = Field(
 )
 
 
+class MaskingStrategies(str, Enum):
+    """Possible options for masking strategy overrides"""
+
+    DELETE = "delete"
+
+
+class MaskingStrategyOverride(BaseModel):
+    """Overrides policy-level masking strategies."""
+
+    strategy: MaskingStrategies
+
+
 class FidesModel(BaseModel):
     """The base model for most top-level Fides objects."""
 
@@ -515,7 +527,9 @@ class CollectionMeta(BaseModel):
     """Collection-level specific annotations used for query traversal"""
 
     after: Optional[List[FidesCollectionKey]] = None
+    erase_after: Optional[List[FidesCollectionKey]] = None
     skip_processing: Optional[bool] = False
+    masking_strategy_override: Optional[MaskingStrategyOverride] = None
 
 
 class DatasetCollection(FidesopsMetaBackwardsCompat):

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -402,6 +402,10 @@ class FidesMeta(BaseModel):
         default=None,
         description="Optionally specify if a field is read-only, meaning it can't be updated or deleted.",
     )
+    custom_request_field: Optional[str] = Field(
+        default=None,
+        description="Optionally specify that a field may be used as a custom request field in DSRs. The value is the name of the field in the DSR.",
+    )
 
     @field_validator("data_type")
     @classmethod

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -478,7 +478,6 @@ class DatasetField(DatasetFieldBase, FidesopsMetaBackwardsCompat):
     ) -> DatasetField:
         """Two validation checks for object fields:
         - If there are sub-fields specified, type should be either empty or 'object'
-        - Additionally object fields cannot have data_categories.
         """
         fields = self.fields
         declared_data_type = None
@@ -494,10 +493,6 @@ class DatasetField(DatasetFieldBase, FidesopsMetaBackwardsCompat):
                     f"The data type '{data_type}' on field '{field_name}' is not compatible with specified sub-fields. Convert to an 'object' field."
                 )
 
-        if (fields or declared_data_type == "object") and self.data_categories:
-            raise ValueError(
-                f"Object field '{field_name}' cannot have specified data_categories. Specify category on sub-field instead"
-            )
         return self
 
 

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Annotated, Dict, List, Optional, Union
+from typing import Annotated, Dict, List, Optional, Union, Any
 
 from packaging.version import InvalidVersion, Version
 from pydantic import (
@@ -73,6 +73,9 @@ class MaskingStrategyOverride(BaseModel):
 
     strategy: MaskingStrategies
 
+class FieldMaskingStrategyOverride(BaseModel):
+    strategy: str
+    configuration: Dict[str, Any]
 
 class FidesModel(BaseModel):
     """The base model for most top-level Fides objects."""
@@ -417,6 +420,10 @@ class FidesMeta(BaseModel):
     custom_request_field: Optional[str] = Field(
         default=None,
         description="Optionally specify that a field may be used as a custom request field in DSRs. The value is the name of the field in the DSR.",
+    )
+    masking_strategy_override = Optional[FieldMaskingStrategyOverride] = Field(
+        default=None,
+        description="Optionally specify a masking strategy override for this field.",
     )
 
     @field_validator("data_type")

--- a/src/fideslang/models.py
+++ b/src/fideslang/models.py
@@ -494,10 +494,6 @@ class DatasetField(DatasetFieldBase, FidesopsMetaBackwardsCompat):
                     f"The data type '{data_type}' on field '{field_name}' is not compatible with specified sub-fields. Convert to an 'object' field."
                 )
 
-        if (fields or declared_data_type == "object") and self.data_categories:
-            raise ValueError(
-                f"Object field '{field_name}' cannot have specified data_categories. Specify category on sub-field instead"
-            )
         return self
 
 

--- a/src/fideslang/parse.py
+++ b/src/fideslang/parse.py
@@ -19,7 +19,7 @@ def parse_dict(
         raise SystemExit(1)
 
     try:
-        parsed_manifest = model_map[resource_type].parse_obj(resource)
+        parsed_manifest = model_map[resource_type].model_validate(resource)
     except Exception as err:
         print(
             "Failed to parse {} from {}:\n{}".format(
@@ -34,7 +34,7 @@ def load_manifests_into_taxonomy(raw_manifests: Dict[str, List[Dict]]) -> Taxono
     """
     Parse the raw resource manifests into resource resources.
     """
-    taxonomy = Taxonomy.parse_obj(
+    taxonomy = Taxonomy.model_validate(
         {
             resource_type: [
                 parse_dict(resource_type, resource) for resource in resource_list

--- a/src/fideslang/parse.py
+++ b/src/fideslang/parse.py
@@ -2,6 +2,7 @@
 This module handles everything related to parsing resources into Pydantic models,
 either from local files or the server.
 """
+
 from typing import Dict, List
 
 from fideslang import FidesModel, Taxonomy, model_map

--- a/src/fideslang/relationships.py
+++ b/src/fideslang/relationships.py
@@ -75,7 +75,7 @@ def get_referenced_missing_keys(taxonomy: Taxonomy) -> Set[FidesKey]:
     """
     referenced_keys: List[Set[FidesKey]] = [
         find_referenced_fides_keys(resource)
-        for resource_type in taxonomy.__fields_set__
+        for resource_type in taxonomy.model_fields_set
         for resource in getattr(taxonomy, resource_type)
     ]
     key_set: Set[FidesKey] = set(

--- a/src/fideslang/utils.py
+++ b/src/fideslang/utils.py
@@ -16,7 +16,7 @@ def get_resource_by_fides_key(
 
     return {
         resource_type: resource
-        for resource_type in taxonomy.__fields_set__
+        for resource_type in taxonomy.model_fields_set
         for resource in getattr(taxonomy, resource_type)
         if resource.fides_key == fides_key
     } or None

--- a/src/fideslang/validation.py
+++ b/src/fideslang/validation.py
@@ -1,6 +1,7 @@
 """
 Contains all of the additional validation for the resource models.
 """
+
 import re
 from collections import Counter
 from typing import Annotated, Dict, List, Optional, Pattern, Set, Tuple

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Common fixtures to be used across tests."""
+
 import os
 from typing import Any, Dict
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,10 @@ import yaml
 from fideslang import models
 
 
+def assert_error_message_includes(exception_info, error_excerpt):
+    assert error_excerpt in str(exception_info.value)
+
+
 @pytest.fixture(scope="session")
 def resources_dict():
     """
@@ -16,14 +20,14 @@ def resources_dict():
     """
     resources_dict: Dict[str, Any] = {
         "data_category": models.DataCategory(
-            organization_fides_key=1,
+            organization_fides_key="1",
             fides_key="user.custom",
             parent_key="user",
             name="Custom Data Category",
             description="Custom Data Category",
         ),
         "dataset": models.Dataset(
-            organization_fides_key=1,
+            organization_fides_key="1",
             fides_key="test_sample_db_dataset",
             name="Sample DB Dataset",
             description="This is a Sample Database Dataset",
@@ -53,13 +57,13 @@ def resources_dict():
             ],
         ),
         "data_subject": models.DataSubject(
-            organization_fides_key=1,
+            organization_fides_key="1",
             fides_key="custom_subject",
             name="Custom Data Subject",
             description="Custom Data Subject",
         ),
         "data_use": models.DataUse(
-            organization_fides_key=1,
+            organization_fides_key="1",
             fides_key="custom_data_use",
             name="Custom Data Use",
             description="Custom Data Use",
@@ -73,7 +77,7 @@ def resources_dict():
             description="Test Organization",
         ),
         "policy": models.Policy(
-            organization_fides_key=1,
+            organization_fides_key="1",
             fides_key="test_policy",
             name="Test Policy",
             version="1.3",
@@ -87,7 +91,7 @@ def resources_dict():
             data_subjects=models.PrivacyRule(matches="ANY", values=[]),
         ),
         "system": models.System(
-            organization_fides_key=1,
+            organization_fides_key="1",
             fides_key="test_system",
             system_type="SYSTEM",
             name="Test System",
@@ -112,7 +116,7 @@ def test_manifests():
             "dataset": [
                 {
                     "name": "Test Dataset 1",
-                    "organization_fides_key": 1,
+                    "organization_fides_key": "1",
                     "datasetType": {},
                     "datasetLocation": "somedb:3306",
                     "description": "Test Dataset 1",
@@ -123,7 +127,7 @@ def test_manifests():
             "system": [
                 {
                     "name": "Test System 1",
-                    "organization_fides_key": 1,
+                    "organization_fides_key": "1",
                     "systemType": "mysql",
                     "description": "Test System 1",
                     "fides_key": "some_system",
@@ -135,7 +139,7 @@ def test_manifests():
                 {
                     "name": "Test Dataset 2",
                     "description": "Test Dataset 2",
-                    "organization_fides_key": 1,
+                    "organization_fides_key": "1",
                     "datasetType": {},
                     "datasetLocation": "somedb:3306",
                     "fides_key": "another_dataset",
@@ -145,7 +149,7 @@ def test_manifests():
             "system": [
                 {
                     "name": "Test System 2",
-                    "organization_fides_key": 1,
+                    "organization_fides_key": "1",
                     "systemType": "mysql",
                     "description": "Test System 2",
                     "fides_key": "another_system",

--- a/tests/fideslang/gvl/test_gvl.py
+++ b/tests/fideslang/gvl/test_gvl.py
@@ -67,19 +67,15 @@ def test_feature_id_to_feature_name():
     assert feature_id_to_feature_name(feature_id=1001) is None
 
 
-
 def test_data_category_id_to_data_categories():
-    assert data_category_id_to_data_categories(1) == [
-            "user.device.ip_address"
-    ]
+    assert data_category_id_to_data_categories(1) == ["user.device.ip_address"]
 
     # let's test one other data category just to be comprehensive
     assert data_category_id_to_data_categories(5) == [
-            "user.account",
-            "user.unique_id",
-            "user.device"
-        ]
-
+        "user.account",
+        "user.unique_id",
+        "user.device",
+    ]
 
     # assert invalid categories raise KeyErrors
     with pytest.raises(KeyError):

--- a/tests/fideslang/gvl/test_gvl.py
+++ b/tests/fideslang/gvl/test_gvl.py
@@ -36,7 +36,7 @@ def test_purpose_to_data_use():
         purpose_to_data_use(12)
 
     with pytest.raises(KeyError):
-        purpose_to_data_use(3, True)
+        purpose_to_data_use(4, True)
 
 
 def test_features():

--- a/tests/fideslang/test_default_taxonomy.py
+++ b/tests/fideslang/test_default_taxonomy.py
@@ -7,7 +7,7 @@ from fideslang.default_taxonomy import DEFAULT_TAXONOMY
 
 taxonomy_counts = {
     "data_category": 85,
-    "data_use": 55,
+    "data_use": 56,
     "data_subject": 15,
 }
 

--- a/tests/fideslang/test_manifests.py
+++ b/tests/fideslang/test_manifests.py
@@ -68,7 +68,7 @@ def test_union_manifests(test_manifests):
                 "name": "Test Dataset 1",
                 "description": "Test Dataset 1",
                 "fides_key": "some_dataset",
-                "organization_fides_key": 1,
+                "organization_fides_key": "1",
                 "datasetType": {},
                 "datasetLocation": "somedb:3306",
                 "datasetTables": [],
@@ -77,7 +77,7 @@ def test_union_manifests(test_manifests):
                 "name": "Test Dataset 2",
                 "description": "Test Dataset 2",
                 "fides_key": "another_dataset",
-                "organization_fides_key": 1,
+                "organization_fides_key": "1",
                 "datasetType": {},
                 "datasetLocation": "somedb:3306",
                 "datasetTables": [],
@@ -86,14 +86,14 @@ def test_union_manifests(test_manifests):
         "system": [
             {
                 "name": "Test System 1",
-                "organization_fides_key": 1,
+                "organization_fides_key": "1",
                 "systemType": "mysql",
                 "description": "Test System 1",
                 "fides_key": "some_system",
             },
             {
                 "name": "Test System 2",
-                "organization_fides_key": 1,
+                "organization_fides_key": "1",
                 "systemType": "mysql",
                 "description": "Test System 2",
                 "fides_key": "another_system",
@@ -122,7 +122,7 @@ def test_ingest_manifests(ingestion_manifest_directory):
     assert sorted(actual_result["dataset"], key=lambda x: x["name"]) == [
         {
             "name": "Test Dataset 1",
-            "organization_fides_key": 1,
+            "organization_fides_key": "1",
             "datasetType": {},
             "datasetLocation": "somedb:3306",
             "description": "Test Dataset 1",
@@ -132,7 +132,7 @@ def test_ingest_manifests(ingestion_manifest_directory):
         {
             "name": "Test Dataset 2",
             "description": "Test Dataset 2",
-            "organization_fides_key": 1,
+            "organization_fides_key": "1",
             "datasetType": {},
             "datasetLocation": "somedb:3306",
             "fides_key": "another_dataset",
@@ -142,14 +142,14 @@ def test_ingest_manifests(ingestion_manifest_directory):
     assert sorted(actual_result["system"], key=lambda x: x["name"]) == [
         {
             "name": "Test System 1",
-            "organization_fides_key": 1,
+            "organization_fides_key": "1",
             "systemType": "mysql",
             "description": "Test System 1",
             "fides_key": "some_system",
         },
         {
             "name": "Test System 2",
-            "organization_fides_key": 1,
+            "organization_fides_key": "1",
             "systemType": "mysql",
             "description": "Test System 2",
             "fides_key": "another_system",

--- a/tests/fideslang/test_models.py
+++ b/tests/fideslang/test_models.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pytest import mark, raises
 
 from fideslang import DataFlow, Dataset, Organization, PrivacyDeclaration, System
@@ -371,6 +373,7 @@ class TestSystem:
                 )
             ],
             vendor_id="gvl.1",
+            vendor_deleted_date=datetime.now(),
             dataset_references=["test_fides_key_dataset"],
             processes_personal_data=True,
             exempt_from_privacy_regulations=False,
@@ -504,4 +507,3 @@ class TestDataset:
 class TestDataUse:
     def test_minimal_data_use(self):
         assert DataUse(fides_key="new_use")
-

--- a/tests/fideslang/test_parse.py
+++ b/tests/fideslang/test_parse.py
@@ -1,19 +1,18 @@
 import pytest
 
-from fideslang import models
-from fideslang import parse
+from fideslang import models, parse
 
 
 @pytest.mark.unit
 def test_parse_manifest():
     expected_result = models.DataCategory(
-        organization_fides_key=1,
+        organization_fides_key="1",
         fides_key="some_resource",
         name="Test resource 1",
         description="Test Description",
     )
     test_dict = {
-        "organization_fides_key": 1,
+        "organization_fides_key": "1",
         "fides_key": "some_resource",
         "name": "Test resource 1",
         "description": "Test Description",
@@ -26,7 +25,7 @@ def test_parse_manifest():
 def test_parse_manifest_no_fides_key_validation_error():
     with pytest.raises(SystemExit):
         test_dict = {
-            "organization_fides_key": 1,
+            "organization_fides_key": "1",
             "name": "Test resource 1",
             "description": "Test Description",
         }
@@ -38,7 +37,7 @@ def test_parse_manifest_no_fides_key_validation_error():
 def test_parse_manifest_resource_type_error():
     with pytest.raises(SystemExit):
         test_dict = {
-            "organization_fides_key": 1,
+            "organization_fides_key": "1",
             "fides_key": "some_resource",
             "name": "Test resource 1",
             "description": "Test Description",

--- a/tests/fideslang/test_relationships.py
+++ b/tests/fideslang/test_relationships.py
@@ -103,7 +103,7 @@ class TestFindReferencedKeys:
         assert referenced_keys == set(expected_referenced_key)
 
     def test_find_referenced_fides_keys_2(self) -> None:
-        test_system = System.construct(
+        test_system = System.model_construct(
             name="test_dc",
             fides_key="test_dc",
             description="test description",
@@ -149,7 +149,7 @@ class TestGetReferencedMissingKeys:
                 ),
             ],
             system=[
-                System.construct(
+                System.model_construct(
                     name="test_system",
                     fides_key="test_system",
                     description="test description",

--- a/tests/fideslang/test_validation.py
+++ b/tests/fideslang/test_validation.py
@@ -717,58 +717,60 @@ class TestValidateDatasetField:
         )
 
     def test_data_categories_at_object_level(self):
-        with pytest.raises(ValidationError) as exc:
-            DatasetField(
-                name="test_field",
-                data_categories=["user"],
-                fides_meta=FidesMeta(
-                    references=None,
-                    identify=None,
-                    primary_key=False,
-                    data_type="object",
-                    length=None,
-                    return_all_elements=None,
-                    read_only=None,
-                ),
-                fields=[DatasetField(name="nested_field")],
-            )
-        assert_error_message_includes(
-            exc, "Object field 'test_field' cannot have specified data_categories"
-        )
 
-    def test_object_field_conflicting_types(self):
-        with pytest.raises(ValidationError) as exc:
-            DatasetField(
-                name="test_field",
-                data_categories=["user"],
-                fides_meta=FidesMeta(
-                    references=None,
-                    identify=None,
-                    primary_key=False,
-                    data_type="string",
-                    length=None,
-                    return_all_elements=None,
-                    read_only=None,
-                ),
-                fields=[DatasetField(name="nested_field")],
-            )
-        assert_error_message_includes(
-            exc, "The data type 'string' on field 'test_field' is not compatible with"
-        )
-
-    def test_data_categories_on_nested_fields(self):
-        DatasetField(
+        field = DatasetField(
             name="test_field",
+            data_categories=["user"],
             fides_meta=FidesMeta(
                 references=None,
                 identify=None,
                 primary_key=False,
                 data_type="object",
                 length=None,
+                return_all_elements=None,
                 read_only=None,
             ),
-            fields=[DatasetField(name="nested_field", data_categories=["user"])],
+            fields=[DatasetField(name="nested_field")],
         )
+
+        assert field
+        assert field.data_categories == ["user"]
+        assert field.fides_meta.data_type == "object"
+
+    def test_data_categories_on_nested_fields(self):
+
+        field = DatasetField(
+            name="test_for_nest",
+            data_categories=["user"],
+            fides_meta=FidesMeta(
+                references=None,
+                identify=None,
+                primary_key=False,
+                data_type="object",
+                length=None,
+                return_all_elements=None,
+                read_only=None,
+            ),
+            fields=[
+                DatasetField(
+                    name="nested_field",
+                    data_categories=["user"],
+                    fides_meta=FidesMeta(
+                        references=None,
+                        identify=None,
+                        primary_key=False,
+                        data_type="string",
+                        length=None,
+                        read_only=None,
+                        data_categories=["user"],
+                    ),
+                )
+            ],
+        )
+
+        assert field
+        assert field.data_categories == ["user"]
+        assert field.fields[0].data_categories == ["user"]
 
 
 class TestCollectionMeta:
@@ -804,7 +806,6 @@ class TestCollectionMeta:
         )
 
         assert meta.erase_after == [FidesCollectionKey("test_dataset.test_collection")]
-
 
 
 class TestAnyUrlString:

--- a/tests/fideslang/test_validation.py
+++ b/tests/fideslang/test_validation.py
@@ -717,20 +717,25 @@ class TestValidateDatasetField:
         )
 
     def test_data_categories_at_object_level(self):
-        # Data categories at the object level ARE allowed now
-        DatasetField(
+
+        field = DatasetField(
             name="test_field",
             data_categories=["user"],
             fides_meta=FidesMeta(
                 references=None,
-                identity=None,
+                identify=None,
                 primary_key=False,
                 data_type="object",
                 length=None,
                 return_all_elements=None,
                 read_only=None,
-            )
+            ),
+            fields=[DatasetField(name="nested_field")],
         )
+
+        assert field
+        assert field.data_categories == ["user"]
+        assert field.fides_meta.data_type == "object"
 
     def test_data_categories_on_nested_fields(self):
 
@@ -756,17 +761,15 @@ class TestValidateDatasetField:
                         primary_key=False,
                         data_type="string",
                         length=None,
-                        return_all_elements=None,
                         read_only=None,
+                        data_categories=["user"],
                     ),
                 )
             ],
         )
 
         assert field
-        assert field.fields
-        print(f"fields: {field.fields}")
-        print(f"field:  {vars(field)}")
+        assert field.data_categories == ["user"]
         assert field.fields[0].data_categories == ["user"]
 
 

--- a/tests/fideslang/test_validation.py
+++ b/tests/fideslang/test_validation.py
@@ -734,23 +734,20 @@ class TestValidateDatasetField:
         )
 
     def test_object_field_conflicting_types(self):
-        with pytest.raises(ValidationError) as exc:
-            DatasetField(
-                name="test_field",
-                data_categories=["user"],
-                fides_meta=FidesMeta(
-                    references=None,
-                    identify=None,
-                    primary_key=False,
-                    data_type="string",
-                    length=None,
-                    return_all_elements=None,
-                    read_only=None,
-                ),
-                fields=[DatasetField(name="nested_field")],
-            )
-        assert_error_message_includes(
-            exc, "The data type 'string' on field 'test_field' is not compatible with"
+    
+        DatasetField(
+            name="test_field",
+            data_categories=["user"],
+            fides_meta=FidesMeta(
+                references=None,
+                identify=None,
+                primary_key=False,
+                data_type="string",
+                length=None,
+                return_all_elements=None,
+                read_only=None,
+            ),
+            fields=[DatasetField(name="nested_field")],
         )
 
     def test_data_categories_on_nested_fields(self):

--- a/tests/fideslang/test_validation.py
+++ b/tests/fideslang/test_validation.py
@@ -729,40 +729,45 @@ class TestValidateDatasetField:
                 length=None,
                 return_all_elements=None,
                 read_only=None,
-            ),
-            fields=[DatasetField(name="nested_field")],
-        )
-
-    def test_object_field_conflicting_types(self):
-    
-        DatasetField(
-            name="test_field",
-            data_categories=["user"],
-            fides_meta=FidesMeta(
-                references=None,
-                identify=None,
-                primary_key=False,
-                data_type="string",
-                length=None,
-                return_all_elements=None,
-                read_only=None,
-            ),
-            fields=[DatasetField(name="nested_field")],
+            )
         )
 
     def test_data_categories_on_nested_fields(self):
-        DatasetField(
-            name="test_field",
+
+        field = DatasetField(
+            name="test_for_nest",
+            data_categories=["user"],
             fides_meta=FidesMeta(
                 references=None,
                 identify=None,
                 primary_key=False,
                 data_type="object",
                 length=None,
+                return_all_elements=None,
                 read_only=None,
             ),
-            fields=[DatasetField(name="nested_field", data_categories=["user"])],
+            fields=[
+                DatasetField(
+                    name="nested_field",
+                    data_categories=["user"],
+                    fides_meta=FidesMeta(
+                        references=None,
+                        identify=None,
+                        primary_key=False,
+                        data_type="string",
+                        length=None,
+                        return_all_elements=None,
+                        read_only=None,
+                    ),
+                )
+            ],
         )
+
+        assert field
+        assert field.fields
+        print(f"fields: {field.fields}")
+        print(f"field:  {vars(field)}")
+        assert field.fields[0].data_categories == ["user"]
 
 
 class TestCollectionMeta:

--- a/tests/fideslang/test_validation.py
+++ b/tests/fideslang/test_validation.py
@@ -717,58 +717,62 @@ class TestValidateDatasetField:
         )
 
     def test_data_categories_at_object_level(self):
-        with pytest.raises(ValidationError) as exc:
-            DatasetField(
-                name="test_field",
-                data_categories=["user"],
-                fides_meta=FidesMeta(
-                    references=None,
-                    identify=None,
-                    primary_key=False,
-                    data_type="object",
-                    length=None,
-                    return_all_elements=None,
-                    read_only=None,
-                ),
-                fields=[DatasetField(name="nested_field")],
-            )
-        assert_error_message_includes(
-            exc, "Object field 'test_field' cannot have specified data_categories"
-        )
 
-    def test_object_field_conflicting_types(self):
-        with pytest.raises(ValidationError) as exc:
-            DatasetField(
-                name="test_field",
-                data_categories=["user"],
-                fides_meta=FidesMeta(
-                    references=None,
-                    identify=None,
-                    primary_key=False,
-                    data_type="string",
-                    length=None,
-                    return_all_elements=None,
-                    read_only=None,
-                ),
-                fields=[DatasetField(name="nested_field")],
-            )
-        assert_error_message_includes(
-            exc, "The data type 'string' on field 'test_field' is not compatible with"
-        )
-
-    def test_data_categories_on_nested_fields(self):
-        DatasetField(
+        field = DatasetField(
             name="test_field",
+            data_categories=["user"],
             fides_meta=FidesMeta(
                 references=None,
                 identify=None,
                 primary_key=False,
                 data_type="object",
                 length=None,
+                return_all_elements=None,
                 read_only=None,
             ),
-            fields=[DatasetField(name="nested_field", data_categories=["user"])],
+            fields=[DatasetField(name="nested_field")],
         )
+
+        assert field
+        assert field.data_categories == ["user"]
+        assert field.fides_meta.data_type == "object"
+        
+
+    def test_data_categories_on_nested_fields(self):
+
+        field = DatasetField(
+            name="test_for_nest",
+            data_categories=["user"],
+            fides_meta=FidesMeta(
+                references=None,
+                identify=None,
+                primary_key=False,
+                data_type="object",
+                length=None,
+                return_all_elements=None,
+                read_only=None,
+            ),
+            fields=[
+                DatasetField(
+                    name="nested_field",
+                    data_categories=["user"],
+                    fides_meta=FidesMeta(
+                        references=None,
+                        identify=None,
+                        primary_key=False,
+                        data_type="string",
+                        length=None,
+                        read_only=None,
+                        data_categories=["user"],
+                    ),
+                )
+            ],
+        )
+
+        assert field
+        assert field.data_categories == ["user"]
+        assert field.fields[0].data_categories == ["user"]
+        
 
 
 class TestCollectionMeta:

--- a/tests/fideslang/test_validation.py
+++ b/tests/fideslang/test_validation.py
@@ -15,6 +15,8 @@ from fideslang.models import (
     FidesDatasetReference,
     FidesMeta,
     FidesModel,
+    MaskingStrategies,
+    MaskingStrategyOverride,
     Policy,
     PolicyRule,
     PrivacyDeclaration,
@@ -642,7 +644,7 @@ class TestValidateFidesopsMeta:
             length=None,
             return_all_elements=None,
             read_only=None,
-            custom_request_field="site_id"
+            custom_request_field="site_id",
         )
 
     def test_specify_both_fidesops_meta_and_fides_meta(self):
@@ -788,6 +790,21 @@ class TestCollectionMeta:
 
     def test_valid_collection_key(self):
         CollectionMeta(after=[FidesCollectionKey("test_dataset.test_collection")])
+
+    def test_delete_masking_strategy(self):
+        meta = CollectionMeta(masking_strategy_override={"strategy": "delete"})
+
+        assert meta.masking_strategy_override == MaskingStrategyOverride(
+            strategy=MaskingStrategies.DELETE
+        )
+
+    def test_erase_after(self):
+        meta = CollectionMeta(
+            erase_after=[FidesCollectionKey("test_dataset.test_collection")]
+        )
+
+        assert meta.erase_after == [FidesCollectionKey("test_dataset.test_collection")]
+
 
 
 class TestAnyUrlString:

--- a/tests/fideslang/test_validation.py
+++ b/tests/fideslang/test_validation.py
@@ -625,6 +625,26 @@ class TestValidateFidesopsMeta:
             read_only=None,
         )
 
+    def test_specify_fides_meta_with_custom_request_field(self):
+        """fidesops_meta copied to fides_meta"""
+        field = DatasetField(
+            name="test_field",
+            fides_meta={"custom_request_field": "site_id", "primary_key": False},
+            fields=[],
+        )
+
+        assert not hasattr(field, "fidesops_meta")
+        assert field.fides_meta == FidesMeta(
+            references=None,
+            identity=None,
+            primary_key=False,
+            data_type=None,
+            length=None,
+            return_all_elements=None,
+            read_only=None,
+            custom_request_field="site_id"
+        )
+
     def test_specify_both_fidesops_meta_and_fides_meta(self):
         """fidesops_meta copied to fides_meta - fides_meta field takes priority"""
         field = DatasetField(

--- a/tests/fideslang/test_validation.py
+++ b/tests/fideslang/test_validation.py
@@ -717,23 +717,20 @@ class TestValidateDatasetField:
         )
 
     def test_data_categories_at_object_level(self):
-        with pytest.raises(ValidationError) as exc:
-            DatasetField(
-                name="test_field",
-                data_categories=["user"],
-                fides_meta=FidesMeta(
-                    references=None,
-                    identify=None,
-                    primary_key=False,
-                    data_type="object",
-                    length=None,
-                    return_all_elements=None,
-                    read_only=None,
-                ),
-                fields=[DatasetField(name="nested_field")],
-            )
-        assert_error_message_includes(
-            exc, "Object field 'test_field' cannot have specified data_categories"
+        # Data categories at the object level ARE allowed now
+        DatasetField(
+            name="test_field",
+            data_categories=["user"],
+            fides_meta=FidesMeta(
+                references=None,
+                identity=None,
+                primary_key=False,
+                data_type="object",
+                length=None,
+                return_all_elements=None,
+                read_only=None,
+            ),
+            fields=[DatasetField(name="nested_field")],
         )
 
     def test_object_field_conflicting_types(self):
@@ -804,7 +801,6 @@ class TestCollectionMeta:
         )
 
         assert meta.erase_after == [FidesCollectionKey("test_dataset.test_collection")]
-
 
 
 class TestAnyUrlString:


### PR DESCRIPTION
Part of HA-399

### Description Of Changes

Add validators to the `Cookies` model and each model that uses a `.cookies` property warning of deprecation

### Code Changes

* [ ] 

### Steps to Confirm

* [ ] 

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Documentation Updated
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
* [ ] Update `CHANGELOG.md`
